### PR TITLE
Refactor the terminal/signer connection

### DIFF
--- a/BlockSettleSigner/HeadlessApp.h
+++ b/BlockSettleSigner/HeadlessApp.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <QObject>
 #include "EncryptionUtils.h"
+#include "HeadlessContainer.h"
 
 namespace spdlog {
    class logger;
@@ -28,6 +29,13 @@ public:
 signals:
    void finished();
 
+/*protected slots:
+   void onAuthenticated();
+   void onConnected();
+   void onDisconnected();
+   void onConnError(const QString &err);
+   void onPacketReceived(Blocksettle::Communication::headless::RequestPacket);*/
+
 private:
    void OnlineProcessing();
    void OfflineProcessing();
@@ -37,8 +45,8 @@ private:
    std::shared_ptr<spdlog::logger>  logger_;
    const std::shared_ptr<SignerSettings>        settings_;
    std::shared_ptr<WalletsManager>              walletsMgr_;
-   std::shared_ptr<ZmqSecuredServerConnection>  connection_;
-   std::shared_ptr<HeadlessContainerListener>   listener_;
+   std::shared_ptr<ZmqSecuredDataConnection>    connection_;
+   std::shared_ptr<HeadlessListener>            listener_;
    std::shared_ptr<OfflineProcessor>            offlineProc_;
    SecureBinaryData                             zmqPubKey_;
    SecureBinaryData                             zmqPrvKey_;

--- a/BlockSettleSigner/QMLApp.cpp
+++ b/BlockSettleSigner/QMLApp.cpp
@@ -101,6 +101,8 @@ QMLAppObj::QMLAppObj(const std::shared_ptr<spdlog::logger> &logger
       connect(dbus_, &DBusNotification::messageClicked, this, &QMLAppObj::onSysTrayMsgClicked);
    }
 #endif // BS_USE_DBUS
+
+/////// TO DO: Generate keys here.
 }
 
 void QMLAppObj::settingsConnections()

--- a/BlockSettleSigner/SignerSettings.cpp
+++ b/BlockSettleSigner/SignerSettings.cpp
@@ -275,9 +275,6 @@ void SignerSettings::parseArguments(const QStringList &args)
       if (!parser.isSet(headlessName)) {
          throw std::logic_error("Local terminal ZMQ pub key is set only in headless connection mode");
       }
-      if (parser.value(localTerminalPubKeyFileName).length() != 40) {
-         throw std::runtime_error("Invalid local terminal ZMQ connection pub key size");
-      }
 
       set(LocalTermZMQPubKeyFile, parser.value(localTerminalPubKeyFileName), false);
    }

--- a/BlockSettleSigner/main.cpp
+++ b/BlockSettleSigner/main.cpp
@@ -155,6 +155,7 @@ bool buildZMQConnFiles(std::shared_ptr<SignerSettings> inSettings
    return true;
 }
 
+// Startup code for the headless (command line) version.
 static int HeadlessApp(int argc, char **argv)
 {
    QCoreApplication app(argc, argv);
@@ -170,18 +171,8 @@ static int HeadlessApp(int argc, char **argv)
    logger->set_level(spdlog::level::debug);
    logger->flush_on(spdlog::level::debug);
 
-   logger->info("Starting BS Signer...");
+   logger->info("Starting BlockSettle Signer (Headless)");
    try {
-      // Go ahead and build the ZMQ connection encryption files, even if
-      // they're not used.
-      if (!buildZMQConnFiles(settings, logger)) {
-         if (logger) {
-            logger->info("[{}] ZMQ connection keypair files could not be "
-               "generated. The ZMQ connection can not be created."
-               , __func__);
-         }
-      }
-
       HeadlessAppObj appObj(logger, settings);
       QObject::connect(&appObj, &HeadlessAppObj::finished, &app
                        , &QCoreApplication::quit);
@@ -245,6 +236,7 @@ public:
    }
 };*/
 
+// Startup code for the GUI.
 static int QMLApp(int argc, char **argv)
 {
    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
@@ -285,7 +277,7 @@ static int QMLApp(int argc, char **argv)
 
    // Go ahead and build the headless connection encryption files, even if we
    // don't use them. If they already exist, we'll leave them alone.
-   logger->info("Starting BS Signer...");
+   logger->info("Starting BlockSettle Signer (GUI)");
    if (!buildZMQConnFiles(settings, logger)) {
       if (logger) {
          logger->info("[{}] ZMQ connection keypair files could not be "


### PR DESCRIPTION
- As part of a local, headless signer refactor, the signer must be supplied with the CurveZMQ pub key file for the connecting terminal. Add the CL arg. Note that this will affect users who, for whatever reasons, want to run the signer locally in headless mode but not such that the terminal spawns the signer. A more robust solution can be designed later if needed, and the user can run the signer in GUI mode as a workaround if required right now.
- Change some variable & function names to be more consistent.