### PR TITLE
Fix invocation of signer GUI by signer terminal binary (Mac-only)

### DIFF
--- a/BlockSettleSigner/HeadlessApp.cpp
+++ b/BlockSettleSigner/HeadlessApp.cpp
@@ -107,9 +107,14 @@ void HeadlessAppObj::startInterface()
       args.push_back("--testnet");
    }
 
+#ifdef __APPLE__
+   std::string guiPath = SystemFilePaths::applicationDir()
+      + "/Blocksettle Signer Gui.app/Contents/MacOS/Blocksettle Signer GUI";
+#else
    std::string guiPath = SystemFilePaths::applicationDir() + "/bs_signer_gui";
 #ifdef WIN32
    guiPath += ".exe";
+#endif
 #endif
 
    if (!SystemFileUtils::fileExist(guiPath)) {


### PR DESCRIPTION
When blocksettle_signer is invoked, it should start the GUI automatically. This doesn't happen on Macs. Fix it.