### PR TITLE
Add signer ID key CL arg for signer GUI invocation ("lightgui")

### DIFF
--- a/BlockSettleSigner/HeadlessApp.cpp
+++ b/BlockSettleSigner/HeadlessApp.cpp
@@ -84,9 +84,12 @@ void HeadlessAppObj::startInterface()
          , __func__);
       return;
    case bs::signer::RunMode::lightgui:
+      serverIDKey = adapterLsn_->getServerConn()->getOwnPubKey();
       logger_->debug("[{}] starting lightgui", __func__);
       args.push_back("--guimode");
       args.push_back("lightgui");
+      args.push_back("--server_id_key");
+      args.push_back(serverIDKey.toHexStr());
       break;
    case bs::signer::RunMode::fullgui:
       serverIDKey = adapterLsn_->getServerConn()->getOwnPubKey();


### PR DESCRIPTION
When running the terminal in local signer mode, the signer GUI binary gets invoked in "lightgui" mode. Add the signer binary's ID key when invoking the GUI binary.