### PR TITLE
Switch ZMQ BIP15X connections to ZMQ_STREAM

### DIFF
--- a/BlockSettleSigner/CMakeLists.txt
+++ b/BlockSettleSigner/CMakeLists.txt
@@ -10,13 +10,16 @@ SET(SOURCES
    HeadlessSettings.cpp
    SignerAdapterListener.cpp
    ${BSNetwork}/ActiveStreamClient.cpp
+   ${BSNetwork}/DataConnection.cpp
    ${BSNetwork}/IdStringGenerator.cpp
    ${BSNetwork}/HeadlessContainerListener.cpp
    ${BSNetwork}/MessageHolder.cpp
    ${BSNetwork}/ZmqContext.cpp
+   ${BSNetwork}/ZmqDataConnection.cpp
    ${BSNetwork}/ZmqHelperFunctions.cpp
    ${BSNetwork}/ZmqServerConnection.cpp
    ${BSNetwork}/ZmqStreamServerConnection.cpp
+   ${BSNetwork}/ZMQ_BIP15X_DataConnection.cpp
    ${BSNetwork}/ZMQ_BIP15X_ServerConnection.cpp
    ${BSNetwork}/ZMQ_BIP15X_Msg.cpp
 )


### PR DESCRIPTION
Among other things, the connections need to be able to tell when the other side has failed. Switch the connections to ZMQ_STREAM connections. Requires the common subtree to be updated.