### PR TITLE
Fix signer option parsing crash

### DIFF
--- a/BlockSettleSigner/HeadlessSettings.cpp
+++ b/BlockSettleSigner/HeadlessSettings.cpp
@@ -87,10 +87,11 @@ bool HeadlessSettings::loadSettings(int argc, char **argv)
 
    }
    catch(const std::exception& e) {
-      // The logger should still be outputting to stdout at this point.
+      // The logger should still be outputting to stdout at this point. Still,
+      // in case this changes, output help directly to stdout.
       logger_->warn("[{}] Signer option error: {}", __func__, e.what());
       logger_->warn("[{}] The following options are available:", __func__);
-      logger_->warn("{}", options.help({ "" }));
+      std::cout << options.help({ "" }) << std::endl;
       logger_->warn("[{}] Signer will now exit.", __func__);
       exit(0);
    }


### PR DESCRIPTION
DESCRIPTION:
When the signer binary is started with unsupported command line options, the signer crashes. Add a try/catch to ensure that the binary can exit cleanly.

TESTING:
On macOS, running blocksettle_signer with unsupported options (e.g., --i_do_not_work) caused the binary to crash and not start. With the fix, the binary shuts down cleanly after warning the user that a bad argument was passed along.