### PR TITLE
Change signer setting string

### DIFF
--- a/BlockSettleSigner/qml/SettingsPage.qml
+++ b/BlockSettleSigner/qml/SettingsPage.qml
@@ -187,7 +187,7 @@ Item {
                 Layout.leftMargin: 10
 
                 CustomLabel {
-                    text: qsTr("AuthKey broadcast")
+                    text: qsTr("Two-way Signer Authentication")
                 }
 
 //                Image {


### PR DESCRIPTION
DESCRIPTION:
PR #228 included a change of a signer setting string for a toggle. Reset the string to a correct title.

TESTING:
Compiled on macOS. Confirmed that the signer GUI included the corrected string.