### PR TITLE
Signer/ui fixes 15.4

### DIFF
--- a/BlockSettleSigner/SignerSettings.cpp
+++ b/BlockSettleSigner/SignerSettings.cpp
@@ -91,8 +91,8 @@ void SignerSettings::settingChanged(int setting)
    case signer::TrustedTerminals:
       emit trustedTerminalsChanged();
       break;
-   case signer::StartupBIP150CTX:
-      emit startupBIP150CTXChanged();
+   case signer::TwoWaySignerAuth:
+      emit twoWaySignerAuthChanged();
       break;
    default:
       break;
@@ -275,9 +275,9 @@ QStringList SignerSettings::trustedTerminals() const
    return result;
 }
 
-bool SignerSettings::startupBIP150CTX() const
+bool SignerSettings::twoWaySignerAuth() const
 {
-   return d_->startup_bip150_ctx();
+   return d_->two_way_signer_auth();
 }
 
 QString SignerSettings::dirDocuments() const
@@ -378,10 +378,10 @@ void SignerSettings::setTrustedTerminals(const QStringList &val)
    settingChanged(signer::Setting::TrustedTerminals);
 }
 
-void SignerSettings::setStartupBIP150CTX(bool val)
+void SignerSettings::setTwoWaySignerAuth(bool val)
 {
-   d_->set_startup_bip150_ctx(val);
-   settingChanged(signer::Setting::StartupBIP150CTX);
+   d_->set_two_way_signer_auth(val);
+   settingChanged(signer::Setting::TwoWaySignerAuth);
 }
 
 QString SignerSettings::secondsToIntervalStr(int s)

--- a/BlockSettleSigner/SignerSettings.h
+++ b/BlockSettleSigner/SignerSettings.h
@@ -32,7 +32,7 @@ class SignerSettings : public QObject
    Q_PROPERTY(QString autoSignWallet READ autoSignWallet WRITE setAutoSignWallet NOTIFY autoSignWalletChanged)
    Q_PROPERTY(bool hideEidInfoBox READ hideEidInfoBox WRITE setHideEidInfoBox NOTIFY hideEidInfoBoxChanged)
    Q_PROPERTY(QStringList trustedTerminals READ trustedTerminals WRITE setTrustedTerminals NOTIFY trustedTerminalsChanged)
-   Q_PROPERTY(bool startupBIP150CTX READ startupBIP150CTX WRITE setStartupBIP150CTX NOTIFY startupBIP150CTXChanged)
+   Q_PROPERTY(bool twoWaySignerAuth READ twoWaySignerAuth WRITE setTwoWaySignerAuth NOTIFY twoWaySignerAuthChanged)
 
 public:
    SignerSettings();
@@ -68,7 +68,7 @@ public:
    bs::signer::Limits limits() const;
    bool hideEidInfoBox() const;
    QStringList trustedTerminals() const;
-   bool startupBIP150CTX() const;
+   bool twoWaySignerAuth() const;
 
    QString dirDocuments() const;
    bs::signer::ui::RunMode runMode() const { return runMode_; }
@@ -87,7 +87,7 @@ public:
    void setLimitManualPwKeepStr(const QString &val);
    void setHideEidInfoBox(bool val);
    void setTrustedTerminals(const QStringList &val);
-   void setStartupBIP150CTX(bool val);
+   void setTwoWaySignerAuth(bool val);
 
    using Settings = Blocksettle::Communication::signer::Settings;
    const std::unique_ptr<Settings> &get() const { return d_; }
@@ -109,7 +109,7 @@ signals:
    void autoSignWalletChanged();
    void hideEidInfoBoxChanged();
    void trustedTerminalsChanged();
-   void startupBIP150CTXChanged();
+   void twoWaySignerAuthChanged();
    void changed(int);
 
 private:

--- a/BlockSettleSigner/qml/AutoSignPage.qml
+++ b/BlockSettleSigner/qml/AutoSignPage.qml
@@ -32,8 +32,7 @@ Item {
 
                 RowLayout {
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 40
-
+                    Layout.preferredHeight: 25
                     CustomLabel {
                         Layout.fillWidth: true
                         text: qsTr("Wallet")
@@ -43,7 +42,8 @@ Item {
                 Loader {
                     active: walletsProxy.loaded
                     sourceComponent: CustomComboBox {
-                        width: 200
+                        width: 150
+                        height: 25
                         enabled: !signerStatus.autoSignActive
                         model: walletsProxy.walletNames
                         currentIndex: walletsProxy.indexOfWalletId(signerSettings.autoSignWallet)
@@ -55,7 +55,7 @@ Item {
 
                 RowLayout {
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 40
+                    Layout.preferredHeight: 25
 
                     CustomLabel {
                         Layout.fillWidth: true
@@ -80,10 +80,11 @@ Item {
 
             SettingsGrid {
                 id: gridLimits
+                columns: 3
 
                 CustomHeader {
                     Layout.fillWidth: true
-                    Layout.columnSpan: 2
+                    Layout.columnSpan: 3
                     text: qsTr("Details")
                     Layout.preferredHeight: 25
                 }
@@ -91,8 +92,11 @@ Item {
                 CustomLabel {
                     text: qsTr("XBT spend limit")
                 }
-                CustomTextInput {
+                CustomLabel {
                     Layout.fillWidth: true
+                }
+                CustomTextInput {
+                    Layout.preferredWidth: 150
                     text: signerSettings.autoSignUnlimited ? qsTr("Unlimited") : signerSettings.limitAutoSignXbt
                     selectByMouse: true
                     id: limitAutoSignXbt
@@ -109,8 +113,11 @@ Item {
                 CustomLabel {
                     text: qsTr("Time limit")
                 }
-                CustomTextInput {
+                CustomLabel {
                     Layout.fillWidth: true
+                }
+                CustomTextInput {
+                    Layout.preferredWidth: 150
                     placeholderText: "e.g. 1h or 15m or 600s or combined"
                     selectByMouse: true
                     text: signerSettings.limitAutoSignTime ? signerSettings.limitAutoSignTime : qsTr("Unlimited")

--- a/BlockSettleSigner/qml/BsDialogs/TerminalKeysDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/TerminalKeysDialog.qml
@@ -36,7 +36,7 @@ CustomDialog {
         Layout.margins: 1
 
         CustomHeader {
-            text: qsTr("Add Terminal Public Key")
+            text: qsTr("Add Terminal ID Key")
             Layout.fillWidth: true
             Layout.preferredHeight: 25
             Layout.topMargin: 5

--- a/BlockSettleSigner/qml/BsDialogs/WalletCreateDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/WalletCreateDialog.qml
@@ -19,8 +19,7 @@ import "../js/helper.js" as JsHelper
 CustomTitleDialogWindow {
     id: root
 
-    property bool primaryWalletExists: false
-    property bool isPrimary: false
+    property bool primaryWalletExists: walletsProxy.primaryWalletExists
 
     property int inputLabelsWidth: 110
 
@@ -36,6 +35,9 @@ CustomTitleDialogWindow {
 
     Component.onCompleted: {
         tfName.text = qsTr("Wallet #%1").arg(walletsProxy.walletNames.length + 1);
+        if (!primaryWalletExists) {
+            cbPrimary.checked = true
+        }
     }
 
     cContentItem: ColumnLayout {
@@ -252,11 +254,10 @@ CustomTitleDialogWindow {
                     walletInfo.desc = tfDesc.text
                     walletInfo.walletId = seed.walletId
                     walletInfo.rootId = seed.walletId
-                    isPrimary = cbPrimary.checked
 
                     var createCallback = function(success, errorMsg) {
                         if (success) {
-                            var mb = JsHelper.resultBox(BSResultBox.ResultType.WalletImport, true, walletInfo)
+                            var mb = JsHelper.resultBox(BSResultBox.ResultType.WalletCreate, true, walletInfo)
                             mb.bsAccepted.connect(acceptAnimated)
                         } else {
                             JsHelper.messageBox(BSMessageBox.Type.Critical
@@ -274,13 +275,13 @@ CustomTitleDialogWindow {
                             passwordData.encType = QPasswordData.Password
                             passwordData.encKey = ""
                             passwordData.textPassword = newPasswordWithConfirm.password
-                            walletsProxy.createWallet(isPrimary, seed, walletInfo, passwordData, createCallback)
+                            walletsProxy.createWallet(cbPrimary.checked, seed, walletInfo, passwordData, createCallback)
                         })
                     }
                     else {
                         // auth eID
                         JsHelper.activateeIdAuth(textInputEmail.text, walletInfo, function(newPasswordData) {
-                            walletsProxy.createWallet(isPrimary, seed, walletInfo, newPasswordData, createCallback)
+                            walletsProxy.createWallet(cbPrimary.checked, seed, walletInfo, newPasswordData, createCallback)
                         })
                     }
                 }

--- a/BlockSettleSigner/qml/BsDialogs/WalletImportDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/WalletImportDialog.qml
@@ -18,9 +18,8 @@ import "../js/helper.js" as JsHelper
 CustomTitleDialogWindow {
     id: root
 
-    property bool primaryWalletExists: false
+    property bool primaryWalletExists: walletsProxy.primaryWalletExists
     property string password
-    property bool isPrimary: false
     property QSeed seed: QSeed{}
     property WalletInfo walletInfo: WalletInfo{}
     property var passwordData: QPasswordData{}
@@ -43,6 +42,12 @@ CustomTitleDialogWindow {
     height: 510
     abortConfirmation: true
     abortBoxType: BSAbortBox.AbortType.WalletImport
+
+    Component.onCompleted: {
+        if (!primaryWalletExists) {
+            cbPrimary.checked = true
+        }
+    }
 
     onEnterPressed: {
         if (btnAccept.enabled) btnAccept.onClicked()
@@ -502,8 +507,6 @@ CustomTitleDialogWindow {
                         walletInfo.walletId = seed.walletId
                         walletInfo.rootId = seed.walletId
 
-                        isPrimary = cbPrimary.checked
-
                         var createCallback = function(success, errorMsg) {
                             if (success) {
                                 var mb = JsHelper.resultBox(BSResultBox.ResultType.WalletImport, true, walletInfo)
@@ -525,13 +528,13 @@ CustomTitleDialogWindow {
                             checkPasswordDialog.type = BSPasswordInput.Type.Confirm
                             checkPasswordDialog.open()
                             checkPasswordDialog.bsAccepted.connect(function() {
-                                walletsProxy.createWallet(isPrimary, seed, walletInfo, passwordData, createCallback)
+                                walletsProxy.createWallet(cbPrimary.checked, seed, walletInfo, passwordData, createCallback)
                             })
                         }
                         else {
                             // auth eID
                             JsHelper.activateeIdAuth(textInputEmail.text, walletInfo, function(newPasswordData) {
-                                 walletsProxy.createWallet(isPrimary, seed, walletInfo, newPasswordData, createCallback)
+                                 walletsProxy.createWallet(cbPrimary.checked, seed, walletInfo, newPasswordData, createCallback)
                             })
                         }
                     }

--- a/BlockSettleSigner/qml/BsStyles/BSStyle.qml
+++ b/BlockSettleSigner/qml/BsStyles/BSStyle.qml
@@ -51,5 +51,4 @@ QtObject {
     property color comboBoxItemBgHighlightedColor: buttonsMainColor
     property color comboBoxItemTextColor: textColor
     property color comboBoxItemTextHighlightedColor: textColor
-
 }

--- a/BlockSettleSigner/qml/SettingsPage.qml
+++ b/BlockSettleSigner/qml/SettingsPage.qml
@@ -180,6 +180,159 @@ Item {
 //                }
             }
 
+            SettingsGrid {
+                id: gridNetwork
+
+                CustomLabel {
+                    text: qsTr("Listen IP address")
+                    Layout.fillWidth: true
+                }
+                CustomTextInput {
+                    placeholderText: "0.0.0.0"
+
+                    Layout.minimumWidth: 310
+                    Layout.preferredWidth: 310
+                    Layout.maximumWidth: 310
+                    Layout.alignment: Qt.AlignRight
+
+                    Layout.rightMargin: 6
+                    text: signerSettings.listenAddress
+                    selectByMouse: true
+                    id: listenAddress
+                    validator: RegExpValidator {
+                        regExp: /^((?:[0-1]?[0-9]?[0-9]?|2[0-4][0-9]|25[0-5])\.){0,3}(?:[0-1]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])$/
+                    }
+                    onEditingFinished: {
+                        signerSettings.listenAddress = text
+                    }
+                }
+
+                CustomLabel {
+                    text: qsTr("Listening port")
+                    Layout.fillWidth: true
+                }
+                CustomTextInput {
+                    placeholderText: "23456"
+
+                    Layout.minimumWidth: 310
+                    Layout.preferredWidth: 310
+                    Layout.maximumWidth: 310
+                    Layout.alignment: Qt.AlignRight
+
+                    Layout.rightMargin: 6
+                    text: signerSettings.listenPort
+                    selectByMouse: true
+                    id: listenPort
+                    validator: IntValidator {
+                        bottom: 0
+                        top: 65535
+                    }
+                    onEditingFinished: {
+                        signerSettings.listenPort = text
+                    }
+                }
+            }
+
+            RowLayout {
+                id: row5
+                Layout.topMargin: 5
+                Layout.fillWidth: true
+                Layout.rightMargin: 10
+                Layout.leftMargin: 10
+
+                CustomLabel {
+                    text: qsTr("Signer ID Key")
+                    Layout.minimumWidth: 125
+                    Layout.preferredWidth: 125
+                    Layout.maximumWidth: 125
+                }
+                CustomLabel {
+                    Layout.fillWidth: true
+                }
+                CustomLabel {
+                    Layout.alignment: Qt.AlignRight
+                    wrapMode: Text.Wrap
+                    text: qmlFactory.headlessPubKey
+                    color: BSStyle.textColor
+                }
+            }
+
+            RowLayout {
+                id: row51
+                Layout.topMargin: 5
+                Layout.fillWidth: true
+                Layout.rightMargin: 10
+                Layout.leftMargin: 10
+
+                CustomLabel {
+                    Layout.fillWidth: true
+                }
+                CustomButton {
+                    id: btnHeadlessKeyCopy
+                    text: qsTr("Copy")
+                    Layout.minimumWidth: 150
+                    Layout.preferredWidth: 150
+                    Layout.maximumWidth: 150
+                    Layout.maximumHeight: 22
+                    Layout.rightMargin: 6
+
+                    onClicked: {
+                        qmlFactory.setClipboard(qmlFactory.headlessPubKey)
+                        btnHeadlessKeyCopy.text = qsTr("Copied")
+                        enabled = false
+                        copiedTimer.start()
+                    }
+
+                    Timer {
+                       id: copiedTimer
+                       repeat: false
+                       interval: 1000
+                       onTriggered: {
+                           btnHeadlessKeyCopy.enabled = true
+                           btnHeadlessKeyCopy.text = qsTr("Copy")
+                       }
+                    }
+                }
+                CustomButton {
+                    text: qsTr("Export")
+                    Layout.minimumWidth: 150
+                    Layout.preferredWidth: 150
+                    Layout.maximumWidth: 150
+                    Layout.maximumHeight: 22
+                    Layout.rightMargin: 6
+                    onClicked: {
+                        exportSignerPubKeyDlg.open()
+                        exportSignerPubKeyDlg.accepted.connect(function(){
+                            var zmqPubKey = qmlFactory.headlessPubKey
+                            JsHelper.saveTextFile(exportSignerPubKeyDlg.fileUrl, zmqPubKey)
+                        })
+                    }
+                    FileDialog {
+                        id: exportSignerPubKeyDlg
+                        visible: false
+                        title: "Save Signer ID Key"
+                        selectFolder: false
+                        selectExisting: false
+                        nameFilters: [ "Key files (*.pub)", "All files (*)" ]
+                        selectedNameFilter: "*.pub"
+                        folder: shortcuts.documents
+                    }
+                }
+            }
+
+            CustomHeader {
+                id: terminalKeys
+                text: qsTr("Terminal Settings")
+                checkable: true
+                checked: true
+                down: true
+                Layout.preferredHeight: 25
+                Layout.fillWidth: true
+                Layout.leftMargin: 10
+                Layout.rightMargin: 10
+                Layout.topMargin: 10
+            }
+
             RowLayout {
                 Layout.topMargin: 5
                 Layout.fillWidth: true
@@ -187,7 +340,7 @@ Item {
                 Layout.leftMargin: 10
 
                 CustomLabel {
-                    text: qsTr("Two-way Signer Authentication")
+                    text: qsTr("Terminal ID Key Authentication")
                 }
 
 //                Image {
@@ -219,201 +372,11 @@ Item {
 
                 CustomSwitch {
                     Layout.alignment: Qt.AlignRight
-                    checked: signerSettings.startupBIP150CTX
+                    checked: signerSettings.twoWaySignerAuth
                     onClicked: {
-                        signerSettings.startupBIP150CTX = checked
+                        signerSettings.twoWaySignerAuth = checked
                     }
                 }
-            }
-
-
-//            RowLayout {
-//                id: row4
-//                Layout.topMargin: 5
-//                Layout.fillWidth: true
-//                Layout.rightMargin: 10
-//                Layout.leftMargin: 10
-
-//                CustomLabel {
-//                    text: qsTr("Signer Private Key")
-//                    Layout.minimumWidth: 125
-//                    Layout.preferredWidth: 125
-//                    Layout.maximumWidth: 125
-//                }
-
-//                CustomLabel {
-//                    Layout.alignment: Qt.AlignLeft
-//                    Layout.fillWidth: true
-//                    wrapMode: Text.Wrap
-//                    text: signerSettings.signerPrvKey
-//                    color: BSStyle.textColor
-
-//                }
-
-//                CustomButton {
-//                    text: qsTr("Select")
-//                    Layout.minimumWidth: 80
-//                    Layout.preferredWidth: 80
-//                    Layout.maximumWidth: 80
-//                    Layout.maximumHeight: 26
-//                    Layout.rightMargin: 6
-//                    onClicked: {
-//                        zmqPrivKeyDlg.folder = "file:///" + JsHelper.folderOfFile(signerSettings.signerPrvKey)
-//                        zmqPrivKeyDlg.open()
-//                        zmqPrivKeyDlg.bsAccepted.connect(function(){
-//                            signerSettings.signerPrvKey = JsHelper.fileUrlToPath(zmqPrivKeyDlg.fileUrl)
-//                        })
-//                    }
-//                    FileDialog {
-//                        id: zmqPrivKeyDlg
-//                        visible: false
-//                        title: "Select Signer Private Key"
-//                        selectFolder: false
-//                    }
-//                }
-//            }
-
-            RowLayout {
-                id: row5
-                Layout.topMargin: 5
-                Layout.fillWidth: true
-                Layout.rightMargin: 10
-                Layout.leftMargin: 10
-
-                CustomLabel {
-                    text: qsTr("Signer Public Key")
-                    Layout.minimumWidth: 125
-                    Layout.preferredWidth: 125
-                    Layout.maximumWidth: 125
-                }
-
-                CustomLabel {
-                    Layout.alignment: Qt.AlignLeft
-                    Layout.fillWidth: true
-                    wrapMode: Text.Wrap
-                    text: qmlFactory.headlessPubKey
-                    color: BSStyle.textColor
-
-                }
-                CustomButton {
-                    id: btnZmqKeyCopy
-                    text: qsTr("Copy")
-                    Layout.minimumWidth: 80
-                    Layout.preferredWidth: 80
-                    Layout.maximumWidth: 80
-                    Layout.maximumHeight: 26
-                    Layout.rightMargin: 6
-
-                    onClicked: {
-                        qmlFactory.setClipboard(qmlFactory.headlessPubKey)
-                        btnZmqKeyCopy.text = qsTr("Copied")
-                        enabled = false
-                        copiedTimer.start()
-                    }
-
-                    Timer {
-                       id: copiedTimer
-                       repeat: false
-                       interval: 1000
-                       onTriggered: {
-                           btnZmqKeyCopy.enabled = true
-                           btnZmqKeyCopy.text = qsTr("Copy")
-                       }
-                    }
-                }
-                CustomButton {
-                    text: qsTr("Export")
-                    Layout.minimumWidth: 80
-                    Layout.preferredWidth: 80
-                    Layout.maximumWidth: 80
-                    Layout.maximumHeight: 26
-                    Layout.rightMargin: 6
-                    onClicked: {
-                        //exportSignerPubKeyDlg.folder = "file:///" + JsHelper.folderOfFile(signerSettings.signerPubKey)
-                        //exportSignerPubKeyDlg.folder = shortcuts.home
-                        exportSignerPubKeyDlg.open()
-                        exportSignerPubKeyDlg.accepted.connect(function(){
-                            var zmqPubKey = qmlFactory.headlessPubKey
-                            JsHelper.saveTextFile(exportSignerPubKeyDlg.fileUrl, zmqPubKey)
-                        })
-                    }
-                    FileDialog {
-                        id: exportSignerPubKeyDlg
-                        visible: false
-                        title: "Save Signer Public Key"
-                        selectFolder: false
-                        selectExisting: false
-                        nameFilters: [ "Key files (*.pub)", "All files (*)" ]
-                        selectedNameFilter: "*.pub"
-                        folder: shortcuts.documents
-                    }
-                }
-            }
-
-            SettingsGrid {
-                id: gridNetwork
-
-                CustomLabel {
-                    text: qsTr("Listen IP address")
-                    Layout.fillWidth: true
-                }
-                CustomTextInput {
-                    placeholderText: "0.0.0.0"
-
-                    Layout.minimumWidth: 171
-                    Layout.preferredWidth: 171
-                    Layout.maximumWidth: 171
-                    Layout.alignment: Qt.AlignRight
-
-                    Layout.rightMargin: 6
-                    text: signerSettings.listenAddress
-                    selectByMouse: true
-                    id: listenAddress
-                    validator: RegExpValidator {
-                        regExp: /^((?:[0-1]?[0-9]?[0-9]?|2[0-4][0-9]|25[0-5])\.){0,3}(?:[0-1]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])$/
-                    }
-                    onEditingFinished: {
-                        signerSettings.listenAddress = text
-                    }
-                }
-
-                CustomLabel {
-                    text: qsTr("Listening port")
-                    Layout.fillWidth: true
-                }
-                CustomTextInput {
-                    placeholderText: "23456"
-
-                    Layout.minimumWidth: 171
-                    Layout.preferredWidth: 171
-                    Layout.maximumWidth: 171
-                    Layout.alignment: Qt.AlignRight
-
-                    Layout.rightMargin: 6
-                    text: signerSettings.listenPort
-                    selectByMouse: true
-                    id: listenPort
-                    validator: IntValidator {
-                        bottom: 0
-                        top: 65535
-                    }
-                    onEditingFinished: {
-                        signerSettings.listenPort = text
-                    }
-                }
-            }
-
-            CustomHeader {
-                id: terminalKeys
-                text: qsTr("Terminal Settings")
-                checkable: true
-                checked: true
-                down: true
-                Layout.preferredHeight: 25
-                Layout.fillWidth: true
-                Layout.leftMargin: 10
-                Layout.rightMargin: 10
-                Layout.topMargin: 10
             }
 
             RowLayout {
@@ -424,7 +387,7 @@ Item {
                 Layout.leftMargin: 10
 
                 CustomLabel {
-                    text: qsTr("Terminals keys")
+                    text: qsTr("Terminals ID Keys")
                     Layout.minimumWidth: 125
                     Layout.preferredWidth: 125
                     Layout.maximumWidth: 125
@@ -436,10 +399,10 @@ Item {
 
                 CustomButton {
                     text: qsTr("Manage")
-                    Layout.minimumWidth: 80
-                    Layout.preferredWidth: 80
-                    Layout.maximumWidth: 80
-                    Layout.maximumHeight: 26
+                    Layout.minimumWidth: 150
+                    Layout.preferredWidth: 150
+                    Layout.maximumWidth: 150
+                    Layout.maximumHeight: 22
                     Layout.rightMargin: 6
                     onClicked: {
                         var dlgTerminals = Qt.createComponent("BsDialogs/TerminalKeysDialog.qml").createObject(mainWindow)

--- a/BlockSettleSigner/qml/StatusPage.qml
+++ b/BlockSettleSigner/qml/StatusPage.qml
@@ -84,7 +84,7 @@ Item {
 
                 RowLayout {
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 40
+                    Layout.preferredHeight: 25
 
                     CustomLabel {
                         Layout.fillWidth: true

--- a/BlockSettleSigner/qml/js/qmlDialogs.js
+++ b/BlockSettleSigner/qml/js/qmlDialogs.js
@@ -17,7 +17,6 @@ function createNewWalletDialog(data) {
         // let user set a password or Auth eID and also name and desc. for the new wallet
         var dlgCreateWallet = Qt.createComponent("../BsDialogs/WalletCreateDialog.qml").createObject(mainWindow)
         dlgNewSeed.setNextChainDialog(dlgCreateWallet)
-        dlgCreateWallet.primaryWalletExists = walletsProxy.primaryWalletExists
         dlgCreateWallet.seed = newSeed
         dlgCreateWallet.open()
     })
@@ -27,7 +26,6 @@ function createNewWalletDialog(data) {
 
 function importWalletDialog(data) {
     var dlgImp = Qt.createComponent("../BsDialogs/WalletImportDialog.qml").createObject(mainWindow)
-    dlgImp.primaryWalletExists = walletsProxy.primaryWalletExists
     dlgImp.open()
     return dlgImp
 }


### PR DESCRIPTION
Signer ui fixes:

- Create/Import dialog - Primary Wallet fix
- Create dialog - result messagebox fix
Signer Settings tab fixes:
- The port and Ip are on top in the Network settings-We display the
Signer ID Key just like we do for the terminal (and have buttons below)
- Keep the Copy / Export / Manage Buttons should be the same size and
orientation as they are in the Terminal
- Signer Public Key is called “Signer ID Key”
- Rename Terminal Keys to “Terminal ID Keys”
- Rename Two-way authentication “Validate Terminal ID
- Move Validate Terminal ID Keys to The Terminal Settings section (on
top)

- startupBIP150CTX reverted back to twoWaySignerAuth