### PR TITLE
Fix data race in signer GUI

### DIFF
--- a/BlockSettleSigner/SignerInterfaceListener.h
+++ b/BlockSettleSigner/SignerInterfaceListener.h
@@ -21,8 +21,10 @@ class SignerAdapter;
 
 using namespace Blocksettle::Communication;
 
-class SignerInterfaceListener : public DataConnectionListener
+class SignerInterfaceListener : public QObject, public DataConnectionListener
 {
+   Q_OBJECT
+
 public:
    SignerInterfaceListener(const std::shared_ptr<spdlog::logger> &logger
       , const std::shared_ptr<ZmqBIP15XDataConnection> &conn, SignerAdapter *parent);
@@ -72,6 +74,8 @@ public:
    }
 
 private:
+   void processData(const std::string &);
+
    void onReady(const std::string &data);
    void onPeerConnected(const std::string &data, bool connected);
    void onPasswordRequested(const std::string &data);

--- a/BlockSettleSigner/interfaces/GUI_QML/QMLApp.cpp
+++ b/BlockSettleSigner/interfaces/GUI_QML/QMLApp.cpp
@@ -92,7 +92,7 @@ QMLAppObj::QMLAppObj(SignerAdapter *adapter, const std::shared_ptr<spdlog::logge
    connect(walletsProxy_.get(), &WalletsProxy::walletsChanged, [this] {
       if (walletsProxy_->walletsLoaded()) {
          if (splashScreen_) {
-            splashScreen_->close();
+            splashScreen_->deleteLater();
             splashScreen_ = nullptr;
          }
       }
@@ -144,7 +144,7 @@ void QMLAppObj::onWalletsSynced()
 {
    logger_->debug("[{}]", __func__);
    if (splashScreen_) {
-      splashScreen_->close();
+      splashScreen_->deleteLater();
       splashScreen_ = nullptr;
    }
    walletsModel_->setWalletsManager(walletsMgr_);

--- a/Deploy/.gitignore
+++ b/Deploy/.gitignore
@@ -1,0 +1,1 @@
+bsterminal.deb


### PR DESCRIPTION
Process ZMQ responses on main thread to fix data race (failed to find callback for id N).
It's difficult to provide reliable steps to reproduce. Scott reported it in BST-1903 and I have this to on virtual machine with release build:

Example log with this problem:

```
05/31/19 08:40:33.986 [D](8512): send packet HeadlessReadyType
05/31/19 08:40:34.172 [D](8502): send packet HeadlessPubKeyRequestType
05/31/19 08:40:34.177 [E](8512): [SignerInterfaceListener::onHeadlessPubKey] failed to find callback for id 2
05/31/19 08:40:34.184 [D](8502): [onReady]
05/31/19 08:40:34.184 [D](8502): send packet SyncWalletInfoType
05/31/19 08:40:34.198 [E](8512): [SignerInterfaceListener::onSyncWalletInfo] failed to find callback for id 3
```