### PR TITLE
Updated wallet seed confirmation dialog size

### DIFF
--- a/BlockSettleSigner/qml/BsDialogs/WalletNewSeedDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/WalletNewSeedDialog.qml
@@ -27,7 +27,7 @@ CustomTitleDialogWindow {
 
     property bool fullScreenMode: true
     width: curPage === 1 ? (fullScreenMode ? 640 : mainWindow.width * 0.75) : 470
-    height: curPage === 1 ? (fullScreenMode ? 800 : mainWindow.height * 0.98) : 265
+    height: curPage === 1 ? (fullScreenMode ? 800 : mainWindow.height * 0.98) : 225
 
     abortConfirmation: true
     abortBoxType: BSAbortBox.WalletCreation
@@ -44,7 +44,7 @@ CustomTitleDialogWindow {
     onCurPageChanged: {
         // Bindings not working here for some reason
         var w = curPage === 1 ? (fullScreenMode ? 640 : mainWindow.width * 0.8) : 470
-        var h = curPage === 1 ? (fullScreenMode ? 800 : mainWindow.width * 0.8) : 265
+        var h = curPage === 1 ? (fullScreenMode ? 800 : mainWindow.width * 0.8) : 225
         sizeChanged(w, h)
     }
 


### PR DESCRIPTION
Task description: https://trello.com/c/be5qeUxp/42-fix-create-wallet-dialog-ui-confirm-wallet-seed

Done:

- Updated height of seed confirmation dialog. This removed extra margin at top.

Before
![blocksettle - save your root private key - confirm lines](https://user-images.githubusercontent.com/18167258/60524522-652ed780-9cf5-11e9-86c6-c7fd01505709.png)

After
![blocksettle - save your root private key - confirm lines - fixed](https://user-images.githubusercontent.com/18167258/60524481-4f211700-9cf5-11e9-9936-47abd7426d6a.png)
