### PR TITLE
Fixed resize on small screen

### DIFF
--- a/BlockSettleSigner/QmlFactory.cpp
+++ b/BlockSettleSigner/QmlFactory.cpp
@@ -1,6 +1,7 @@
 #include "QmlFactory.h"
 #include <QApplication>
 #include <QClipboard>
+#include <QQuickWindow>
 #include <QKeyEvent>
 #include <spdlog/spdlog.h>
 #include "AuthProxy.h"
@@ -118,6 +119,15 @@ void QmlFactory::setClipboard(const QString &text) const
 QString QmlFactory::getClipboard() const
 {
    return QApplication::clipboard()->text();
+}
+
+QRect QmlFactory::frameSize(QObject *window) const
+{
+   auto win = qobject_cast<QQuickWindow *>(window);
+   if (win) {
+      return win->frameGeometry();
+   }
+   return QRect();
 }
 
 void QmlFactory::installEventFilterToObj(QObject *object)

--- a/BlockSettleSigner/QmlFactory.h
+++ b/BlockSettleSigner/QmlFactory.h
@@ -95,6 +95,7 @@ public:
    // service functions
    Q_INVOKABLE void setClipboard(const QString &text) const;
    Q_INVOKABLE QString getClipboard() const;
+   Q_INVOKABLE QRect frameSize(QObject *window) const;
    Q_INVOKABLE void installEventFilterToObj(QObject *object);
    bool eventFilter(QObject *object, QEvent *event) override;
 

--- a/BlockSettleSigner/qml/mainLight.qml
+++ b/BlockSettleSigner/qml/mainLight.qml
@@ -39,8 +39,10 @@ ApplicationWindow {
     }
     onHeightChanged: {
         if (height > Screen.desktopAvailableHeight) {
+            let frameSize = qmlFactory.frameSize(mainWindow)
+            let h = frameSize.height > height ? frameSize.height - height : 0
             y = 0
-            height = Screen.desktopAvailableHeight
+            height = Screen.desktopAvailableHeight - h
         }
         emitSizeChanged()
     }


### PR DESCRIPTION
Depends on task: https://trello.com/c/BhONuV4X/51-when-open-create-wallet-dialog-loosing-buttons-on-bottom-at-screens-with-small-height

Due the dialogs are non-resizable (on Windows) in light (headless) mode the create wallet dialog
cannot be adjust automatically to fit desktop size. This causes to unavailable buttons at bottom.
Previously code has been improved to allow adjust content when window resized.

Done:

- When size of window containing headless dialog is changed it is automatically adjusted to fit desktop. If width or height of dialog is greater than desktop's one it is forced to be overwritten with maximally allowen one. Window title bar is considered.