### PR TITLE
Fixed window "create new wallet"

### DIFF
--- a/BlockSettleSigner/qml/BsDialogs/WalletCreateDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/WalletCreateDialog.qml
@@ -31,7 +31,7 @@ CustomTitleDialogWindow {
     height: 470
     abortConfirmation: true
     abortBoxType: BSAbortBox.AbortType.WalletCreation
-    title: qsTr("Create New Wallet")
+    title: qsTr("Manage encryption")
 
     Component.onCompleted: {
         tfName.text = walletsProxy.generateNextWalletName();

--- a/BlockSettleSigner/qml/js/qmlDialogs.js
+++ b/BlockSettleSigner/qml/js/qmlDialogs.js
@@ -89,6 +89,9 @@ function createNewWalletDialog(data) {
         var dlgCreateWallet = Qt.createComponent("../BsDialogs/WalletCreateDialog.qml").createObject(mainWindow)
         dlgNewSeed.setNextChainDialog(dlgCreateWallet)
         dlgCreateWallet.seed = newSeed
+        dlgCreateWallet.bsResized.connect(function() {
+            mainWindow.moveMainWindowToScreenCenter()
+        })
         dlgCreateWallet.open()
     })
     if (Object.keys(mainWindow).indexOf("currentDialog") != -1) {


### PR DESCRIPTION
Task: https://trello.com/c/FOOvUJUg/52-title-manage-encryption-placing-not-centered

Done:

* Centered window "create new wallet"
* Changed title from "Create New Wallet" to "Manage encryption"