### PR TITLE
Use random signer GUI port

### DIFF
--- a/BlockSettleSigner/HeadlessApp.h
+++ b/BlockSettleSigner/HeadlessApp.h
@@ -82,6 +82,7 @@ private:
 
    ProcessControl             guiProcess_;
    std::atomic<bs::signer::BindStatus> signerBindStatus_{bs::signer::BindStatus::Inactive};
+   int interfacePort_{};
 };
 
 #endif // __HEADLESS_APP_H__

--- a/BlockSettleSigner/HeadlessSettings.h
+++ b/BlockSettleSigner/HeadlessSettings.h
@@ -31,7 +31,6 @@ public:
    std::string listenAddress() const;
    std::string acceptFrom() const;
    std::string listenPort() const;
-   std::string interfacePort() const { return "23457"; }
    std::string getTermIDKeyStr() const { return termIDKeyStr_; }
    bool getTermIDKeyBin(BinaryData& keyBuf);
    std::string logFile() const { return logFile_; }

--- a/BlockSettleSigner/SignerAdapter.h
+++ b/BlockSettleSigner/SignerAdapter.h
@@ -39,7 +39,7 @@ class SignerAdapter : public QObject
 public:
    SignerAdapter(const std::shared_ptr<spdlog::logger> &logger
       , const std::shared_ptr<QmlBridge> &qmlBridge
-      , const NetworkType netType, const BinaryData* inSrvIDKey = nullptr);
+      , const NetworkType netType, int signerPort, const BinaryData* inSrvIDKey = nullptr);
    ~SignerAdapter() override;
 
    SignerAdapter(const SignerAdapter&) = delete;
@@ -116,7 +116,7 @@ signals:
 
 private:
    std::shared_ptr<spdlog::logger>  logger_;
-   NetworkType netType_;
+   const NetworkType netType_;
    std::shared_ptr<SignContainer>   signContainer_;
    std::shared_ptr<bs::sync::WalletsManager> walletsMgr_;
    std::shared_ptr<QmlFactory>               qmlFactory_;

--- a/BlockSettleSigner/SignerSettings.cpp
+++ b/BlockSettleSigner/SignerSettings.cpp
@@ -22,6 +22,9 @@ static QString runModeHelp = QObject::tr("GUI run mode [fullgui|litegui]");
 static const QString srvIDKeyName = QString::fromStdString("server_id_key");
 static QString srvIDKeyHelp = QObject::tr("The server's compressed BIP 150 ID key (hex)");
 
+static const QString portName = QString::fromStdString("port");
+static const QString portHelp = QObject::tr("Local TCP connection port to signer process");
+
 namespace {
 
 double convertFromSatoshi(uint64_t satoshi)
@@ -185,6 +188,7 @@ bool SignerSettings::loadSettings(const QStringList &args)
    parser.addOption({ testnetName, testnetHelp });
    parser.addOption({ runModeName, runModeHelp, runModeName });
    parser.addOption({ srvIDKeyName, srvIDKeyHelp, srvIDKeyName });
+   parser.addOption({ portName, portHelp, portName });
 
    parser.process(args);
 
@@ -209,6 +213,12 @@ bool SignerSettings::loadSettings(const QStringList &args)
 
    if (parser.isSet(srvIDKeyName)) {
       srvIDKey_ = parser.value(srvIDKeyName).toStdString();
+   }
+
+   if (parser.isSet(portName)) {
+      signerPort_ = parser.value(portName).toInt();
+   } else {
+      return false;
    }
 
    // This switch is needed when terminal is started with testnet connection and local signer used.

--- a/BlockSettleSigner/SignerSettings.h
+++ b/BlockSettleSigner/SignerSettings.h
@@ -96,6 +96,8 @@ public:
    static QString secondsToIntervalStr(int);
    static int intervalStrToSeconds(const QString &);
 
+   int signerPort() { return signerPort_; }
+
 signals:
    void offlineChanged();
    void testNetChanged();
@@ -122,6 +124,7 @@ private:
    std::string writableDir_;
    std::string fileName_;
    std::string srvIDKey_;
+   int signerPort_{};
    bs::signer::ui::RunMode runMode_{};
    std::unique_ptr<Settings> d_;
 };

--- a/BlockSettleSigner/interfaces/GUI_QML/main.cpp
+++ b/BlockSettleSigner/interfaces/GUI_QML/main.cpp
@@ -188,7 +188,7 @@ static int QMLApp(int argc, char **argv)
             "command line. Functionality may be limited.", __func__);
       }
 
-      SignerAdapter adapter(logger, qmlBridge, settings->netType(), &srvIDKey);
+      SignerAdapter adapter(logger, qmlBridge, settings->netType(), settings->signerPort(), &srvIDKey);
       adapter.setCloseHeadless(settings->closeHeadless());
 
       QMLAppObj qmlAppObj(&adapter, logger, settings, splashScreen, engine.rootContext());


### PR DESCRIPTION
Right now it's not possible to use two terminals (with local signers) on same PC because we use one port for GUI interface connections. And It could be problematic if port 23457 is already used by some other program. Let's switch to random signer GUI port selection.