### PR TITLE
Fix data races reported by TSAN at signer GUI shutdown

### DIFF
--- a/BlockSettleSigner/SignerAdapter.cpp
+++ b/BlockSettleSigner/SignerAdapter.cpp
@@ -62,6 +62,7 @@ SignerAdapter::~SignerAdapter()
 {
    if (closeHeadless_) {
       listener_->send(signer::RequestCloseType, "");
+      listener_->closeConnection();
    }
 }
 

--- a/BlockSettleSigner/SignerInterfaceListener.cpp
+++ b/BlockSettleSigner/SignerInterfaceListener.cpp
@@ -607,7 +607,14 @@ void SignerInterfaceListener::requestPasswordForToken(bs::sync::PasswordDialogDa
 
 void SignerInterfaceListener::shutdown()
 {
-   QApplication::quit();
+   QMetaObject::invokeMethod(qApp, [] {
+      QApplication::quit();
+   });
+}
+
+void SignerInterfaceListener::closeConnection()
+{
+   connection_->closeConnection();
 }
 
 QmlCallbackBase *SignerInterfaceListener::createQmlPasswordCallback()

--- a/BlockSettleSigner/SignerInterfaceListener.h
+++ b/BlockSettleSigner/SignerInterfaceListener.h
@@ -84,6 +84,7 @@ public:
 
    void setQmlFactory(const std::shared_ptr<QmlFactory> &qmlFactory);
 
+   void closeConnection();
 private:
    void processData(const std::string &);
 
@@ -115,8 +116,8 @@ private:
    void requestPasswordForToken(bs::sync::PasswordDialogData *dialogData, bs::hd::WalletInfo *walletInfo);
 
    void shutdown();
-   bs::signer::QmlCallbackBase *createQmlPasswordCallback();
 
+   bs::signer::QmlCallbackBase *createQmlPasswordCallback();
 private:
    std::shared_ptr<spdlog::logger>           logger_;
    std::shared_ptr<ZmqBIP15XDataConnection>  connection_;
@@ -138,7 +139,6 @@ private:
    std::map<bs::signer::RequestId, std::function<void(bs::error::ErrorCode errorCode)>> cbAutoSignReqs_;
 
    std::shared_ptr<QmlBridge>  qmlBridge_;
-
 };
 
 


### PR DESCRIPTION
Here is a workaround for some TSAN reported data races for signer GUI shutdown.
The problem here is that SignerAdapter is not destroyed at shutdown (it tries call QApplication::quit while it's already destroying and main loop was stopped). The workaround is to stop connection before that.