### PR TITLE
Revert "BST-2129: use only one address type in each XBT leaf"

### DIFF
--- a/BlockSettleSigner/SignerAdapterContainer.h
+++ b/BlockSettleSigner/SignerAdapterContainer.h
@@ -81,9 +81,8 @@ public:
       const std::set<BinaryData>& addrSet, std::function<void(bs::sync::SyncState)>) override {}
    void extendAddressChain(const std::string &walletId, unsigned count, bool extInt,
       const std::function<void(const std::vector<std::pair<bs::Address, std::string>> &)> &) override {}
-   void syncNewAddresses(const std::string &walletId, const std::vector<std::string> &
-      , const std::function<void(const std::vector<std::pair<bs::Address, std::string>> &)> &
-      , bool persistent = true) override {}
+   void syncNewAddresses(const std::string &walletId, const std::vector<std::pair<std::string, AddressEntryType>> &
+      , const std::function<void(const std::vector<std::pair<bs::Address, std::string>> &)> &, bool persistent = true) override {}
 
    bool isWalletOffline(const std::string &id) const override { return (woWallets_.find(id) != woWallets_.end()); }
 

--- a/BlockSettleSigner/SignerInterfaceListener.cpp
+++ b/BlockSettleSigner/SignerInterfaceListener.cpp
@@ -362,8 +362,7 @@ void SignerInterfaceListener::onSyncHDWallet(const std::string &data, bs::signer
       std::vector<bs::sync::HDWalletData::Leaf> leaves;
       for (int j = 0; j < group.leaves_size(); ++j) {
          const auto leaf = group.leaves(j);
-         leaves.push_back({ leaf.id(), bs::hd::Path::fromString(leaf.path())
-            , false, leaf.extra_data() });
+         leaves.push_back({ leaf.id(), leaf.index(), false, leaf.extra_data() });
       }
       result.groups.push_back({ static_cast<bs::hd::CoinType>(group.type()), leaves });
    }
@@ -434,7 +433,7 @@ void SignerInterfaceListener::onCreateWO(const std::string &data, bs::signer::Re
             addresses.push_back({ addr.index()
                , static_cast<AddressEntryType>(addr.aet()) });
          }
-         leaves.push_back({ leaf.id(), bs::hd::Path::fromString(leaf.path()), leaf.public_key()
+         leaves.push_back({ leaf.id(), leaf.index(), leaf.public_key()
             , leaf.chain_code(), addresses });
       }
       result.groups.push_back({ static_cast<bs::hd::CoinType>(group.type()), leaves });

--- a/BlockSettleSigner/WalletsProxy.cpp
+++ b/BlockSettleSigner/WalletsProxy.cpp
@@ -246,15 +246,15 @@ void WalletsProxy::exportWatchingOnly(const QString &walletId, const QString &fi
             auto lock = newWallet->lockForEncryption(passwordData->password);
             for (const auto &leaf : group->getLeaves()) {
                try {
-                  auto newLeaf = newGroup->createLeaf(leaf->path());
+                  auto newLeaf = newGroup->createLeaf(leaf->index());
                   if (!newLeaf) {
                      throw std::runtime_error("uncreatable");
                   }
                   for (const auto &addr : leaf->getExtAddressList()) {
-                     newLeaf->getNewExtAddress();
+                     newLeaf->getNewExtAddress(addr.getType());
                   }
                   for (const auto &addr : leaf->getIntAddressList()) {
-                     newLeaf->getNewIntAddress();
+                     newLeaf->getNewIntAddress(addr.getType());
                   }
                   logger_->debug("[WalletsProxy::exportWatchingOnly] leaf {} has {} + {} addresses"
                      , newLeaf->walletId(), newLeaf->getExtAddressCount(), newLeaf->getIntAddressCount());
@@ -599,7 +599,7 @@ std::shared_ptr<bs::sync::hd::Wallet> WalletsProxy::getWoSyncWallet(const bs::sy
       for (const auto &groupEntry : wo.groups) {
          auto group = result->createGroup(static_cast<bs::hd::CoinType>(groupEntry.type), false);
          for (const auto &leafEntry : groupEntry.leaves) {
-            group->createLeaf(leafEntry.path, leafEntry.id);
+            group->createLeaf(leafEntry.index, leafEntry.id);
          }
       }
       return result;


### PR DESCRIPTION
This reverts commit a2dbbb42b07ee0016b1223a3a159463b4b17e159.