### PR TITLE
disable compiler warnings in release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,9 @@ ENDIF()
 SET( PROJECT_BINARY_DIR ${BLOCK_SETTLE_ROOT}/build_terminal/${CMAKE_BUILD_TYPE} )
 SET( EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin )
 
+include(CompilerWarnings)
+include(CompilerColorDiagnostics)
+
 IF( WIN32 )
    # output libs to same path as binaries on windows just to make life easier
    IF(BSTERMINAL_SHARED_LIBS)


### PR DESCRIPTION
Previous iteration of this change 26a4cc56 broke the debug build on
windows, and it was reverted in 145358cb, this problem is fixed in:

https://github.com/BlockSettle/common/pull/1303

Activate the two cmake modules:

- `common/build_scripts/CMakeModules/CompilerWarnings.cmake`

- `common/build_scripts/CMakeModules/CompilerColorDiagnostics.cmake`

Update common to latest.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>