### PR TITLE
Fix Headless signer flickering by init all dialogs during signer startup

### DIFF
--- a/BlockSettleSigner/qml/js/helper.js
+++ b/BlockSettleSigner/qml/js/helper.js
@@ -572,3 +572,32 @@ function truncString(string, maxLength) {
 String.prototype.truncString = function(maxLength){
    return truncString(this, maxLength)
 }
+
+function initJSDialogs() {
+    let folderListObj = Qt.createQmlObject(
+        'import Qt.labs.folderlistmodel 2.12;FolderListModel { property bool isReady: status === FolderListModel.Ready; folder : "../BsDialogs/"; }'
+        , mainWindow);
+
+    folderListObj.statusChanged.connect(function() {
+        if (!folderListObj.isReady)
+            return
+        for (let i = 0; i < folderListObj.count; ++i) {
+            if (folderListObj.get(i, "fileSuffix") !== 'qml') {
+                continue;
+            }
+
+            let fileName = folderListObj.get(i, "fileName");
+            let childComp = Qt.createComponent("../BsDialogs/" + fileName);
+            let childObj = childComp.incubateObject(null);
+            if (childObj.status !== Component.Ready) {
+                childObj.onStatusChanged = function(status) {
+                    if (status === Component.Ready) {
+                        childObj.object.destroy();
+                    }
+                }
+            } else {
+                childObj.object.destroy();
+            }
+        }
+    })
+}

--- a/BlockSettleSigner/qml/mainLite.qml
+++ b/BlockSettleSigner/qml/mainLite.qml
@@ -37,6 +37,7 @@ ApplicationWindow {
         hide()
         qmlFactory.installEventFilterToObj(mainWindow)
         qmlFactory.applyWindowFix(mainWindow)
+        JsHelper.initJSDialogs()
     }
 
     color: BSStyle.backgroundColor


### PR DESCRIPTION
Issue: visible resizing of main headless signer window while showing dialog first time 