### PR TITLE
enable LTO for release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,9 @@ ENDIF()
 SET( PROJECT_BINARY_DIR ${BLOCK_SETTLE_ROOT}/build_terminal/${CMAKE_BUILD_TYPE} )
 SET( EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin )
 
+include(GCCToolchain)
+include(LLVMToolchain)
+include(LTO)
 include(CompilerWarnings)
 include(CompilerColorDiagnostics)
 


### PR DESCRIPTION
LTO is link-time-optimizations and can improve performance, especially
when linking static libs.

Enable the gcc toolchain, LLVM toolchain and LTO modules previously
added to common here:

LTO is also enabled for Visual Studio.

https://github.com/BlockSettle/common/pull/1380

The toolchain modules find and tell cmake to use compiler-specific build
utilities, which may be necessary for LTO to work, and is harmless
otherwise. In the case of gcc, this is definitely required.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>