### PR TITLE
[build] Install Blocksettle icons and BlockSettle .desktop files

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -73,7 +73,6 @@ Homepage: http://blocksettle.com
 
 Package: bsterminal
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: BlockSettle bitcoin terminal and wallet manager
  This application is as terminal for BlockSettle's real-time
  settlement network, but can also act as a comprehensive Bitcoin

--- a/debian/rules
+++ b/debian/rules
@@ -15,6 +15,7 @@ override_dh_auto_install:
 	mkdir -p $(CURDIR)/debian/bsterminal/usr/bin/
 	cp $(CURDIR)/build_terminal/Release/bin/blocksettle $(CURDIR)/debian/bsterminal/usr/bin/
 	cp $(CURDIR)/build_terminal/Release/bin/blocksettle_signer $(CURDIR)/debian/bsterminal/usr/bin/
+	cp $(CURDIR)/Deploy/Ubuntu/usr -r $(CURDIR)/debian/bsterminal/
 
 override_dh_auto_clean:
 	dh_auto_clean


### PR DESCRIPTION
Installs required icons and .desktop files for xdg desktop runtime.
files are copied over at build time without breaking the current CI
and duplication.

also removes the Depends option to address the review comment (pavel)