### PR TITLE
[build] Install Blocksettle icons and BlockSettle .desktop files

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -73,7 +73,7 @@ Homepage: http://blocksettle.com
 
 Package: bsterminal
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, desktop-file-utils, xdg-utils
 Description: BlockSettle bitcoin terminal and wallet manager
  This application is as terminal for BlockSettle's real-time
  settlement network, but can also act as a comprehensive Bitcoin

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+for SIZE in 32 48 64 128 256
+do
+	xdg-icon-resource install --novendor --context apps --size $SIZE /usr/share/blocksettle/icons/blocksettle_$SIZE.png blocksettle
+	xdg-icon-resource install --novendor --context apps --size $SIZE /usr/share/blocksettle/icons/blocksettle_signer_$SIZE.png blocksettle_signer
+done
+
+update-desktop-database
+
+exit 0

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+for SIZE in 32 48 64 128 256
+do
+    xdg-icon-resource uninstall --size $SIZE blocksettle
+    xdg-icon-resource uninstall --size $SIZE blocksettle_signer
+done
+
+update-desktop-database
+
+exit 0

--- a/debian/rules
+++ b/debian/rules
@@ -15,6 +15,7 @@ override_dh_auto_install:
 	mkdir -p $(CURDIR)/debian/bsterminal/usr/bin/
 	cp $(CURDIR)/build_terminal/Release/bin/blocksettle $(CURDIR)/debian/bsterminal/usr/bin/
 	cp $(CURDIR)/build_terminal/Release/bin/blocksettle_signer $(CURDIR)/debian/bsterminal/usr/bin/
+	cp $(CURDIR)/Deploy/Ubuntu/usr -r $(CURDIR)/debian/bsterminal/
 
 override_dh_auto_clean:
 	dh_auto_clean


### PR DESCRIPTION
Installs required icons and .desktop files for xdg desktop runtime.
Files are copied over at build time without breaking the current CI
and duplication.