### PR TITLE
Change resize options from contentResize to Interactive resize

### DIFF
--- a/BlockSettleUILib/CCWidget.cpp
+++ b/BlockSettleUILib/CCWidget.cpp
@@ -32,7 +32,8 @@ void CCWidget::SetPortfolioModel(const std::shared_ptr<CCPortfolioModel>& model)
    const auto &walletsManager = model->walletsManager();
 
    ui_->treeViewCC->setModel(model.get());
-   ui_->treeViewCC->header()->setSectionResizeMode(QHeaderView::Stretch);
+   ui_->treeViewCC->header()->setSectionResizeMode(QHeaderView::Interactive);
+   ui_->treeViewCC->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
 
    connect(model.get(), &CCPortfolioModel::rowsInserted, this, &CCWidget::onRowsInserted);
    connect(assetManager_.get(), &AssetManager::totalChanged, this, &CCWidget::updateTotalAssets);

--- a/BlockSettleUILib/PortfolioWidget.cpp
+++ b/BlockSettleUILib/PortfolioWidget.cpp
@@ -67,7 +67,7 @@ PortfolioWidget::PortfolioWidget(QWidget* parent)
    ui_->treeViewUnconfirmedTransactions->setContextMenuPolicy(Qt::CustomContextMenu);
    connect(ui_->treeViewUnconfirmedTransactions, &QTreeView::customContextMenuRequested, this, &PortfolioWidget::showContextMenu);
    connect(ui_->treeViewUnconfirmedTransactions, &QTreeView::activated, this, &PortfolioWidget::showTransactionDetails);
-   ui_->treeViewUnconfirmedTransactions->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
+   ui_->treeViewUnconfirmedTransactions->header()->setSectionResizeMode(QHeaderView::Interactive);
 
    actionCopyAddr_ = new QAction(tr("&Copy Address"));
    connect(actionCopyAddr_, &QAction::triggered, [this]() {
@@ -101,6 +101,8 @@ void PortfolioWidget::SetTransactionsModel(const std::shared_ptr<TransactionsVie
       , Qt::SortOrder::DescendingOrder);
    ui_->treeViewUnconfirmedTransactions->hideColumn(
       static_cast<int>(TransactionsViewModel::Columns::TxHash));
+   ui_->treeViewUnconfirmedTransactions->header()->setSectionResizeMode(static_cast<int>(TransactionsViewModel::Columns::Date)
+      , QHeaderView::ResizeToContents);
 }
 
 void PortfolioWidget::init(const std::shared_ptr<ApplicationSettings> &appSettings

--- a/BlockSettleUILib/Trading/RFQReplyWidget.cpp
+++ b/BlockSettleUILib/Trading/RFQReplyWidget.cpp
@@ -186,9 +186,11 @@ void RFQReplyWidget::init(const std::shared_ptr<spdlog::logger> &logger
    connect(quoteProvider_.get(), &QuoteProvider::quoteNotifCancelled, ui_->widgetQuoteRequests, &QuoteRequestsWidget::onQuoteNotifCancelled);
    connect(quoteProvider_.get(), &QuoteProvider::signTxRequested, this, &RFQReplyWidget::onSignTxRequested);
 
-   ui_->treeViewOrders->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
    ui_->treeViewOrders->setModel(orderListModel);
    ui_->treeViewOrders->initWithModel(orderListModel);
+   ui_->treeViewOrders->header()->setSectionResizeMode(QHeaderView::Interactive);
+   ui_->treeViewOrders->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+
 
    connect(celerClient_.get(), &BaseCelerClient::OnConnectedToServer, this, &RFQReplyWidget::onConnectedToCeler);
    connect(celerClient_.get(), &BaseCelerClient::OnConnectionClosed, this, &RFQReplyWidget::onDisconnectedFromCeler);

--- a/BlockSettleUILib/Trading/RFQRequestWidget.cpp
+++ b/BlockSettleUILib/Trading/RFQRequestWidget.cpp
@@ -190,9 +190,10 @@ void RFQRequestWidget::init(std::shared_ptr<spdlog::logger> logger
 
    ui_->pageRFQTicket->init(logger, authAddressManager, assetManager, quoteProvider, container, armory);
 
-   ui_->treeViewOrders->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
    ui_->treeViewOrders->setModel(orderListModel);
    ui_->treeViewOrders->initWithModel(orderListModel);
+   ui_->treeViewOrders->header()->setSectionResizeMode(QHeaderView::Interactive);
+   ui_->treeViewOrders->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
    connect(quoteProvider_.get(), &QuoteProvider::quoteOrderFilled, [](const std::string &quoteId) {
       NotificationCenter::notify(bs::ui::NotifyType::CelerOrder, {true, QString::fromStdString(quoteId)});
    });

--- a/BlockSettleUILib/WalletsWidget.cpp
+++ b/BlockSettleUILib/WalletsWidget.cpp
@@ -228,7 +228,6 @@ void WalletsWidget::setUsername(const QString& username)
 void WalletsWidget::InitWalletsView(const std::string& defaultWalletId)
 {
    walletsModel_ = new WalletsViewModel(walletsManager_, defaultWalletId, signingContainer_, ui_->treeViewWallets);
-   ui_->treeViewWallets->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
    ui_->treeViewWallets->setModel(walletsModel_);
    ui_->treeViewWallets->setFocus(Qt::ActiveWindowFocusReason);
    ui_->treeViewWallets->setItemsExpandable(true);
@@ -237,6 +236,8 @@ void WalletsWidget::InitWalletsView(const std::string& defaultWalletId)
    // show the column as per BST-1520
    //ui_->treeViewWallets->hideColumn(static_cast<int>(WalletsViewModel::WalletColumns::ColumnID));
    walletsModel_->LoadWallets();
+   ui_->treeViewWallets->header()->setSectionResizeMode(QHeaderView::Interactive);
+   ui_->treeViewWallets->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
 
    connect(ui_->walletPropertiesButton, &QPushButton::clicked, this, &WalletsWidget::showSelectedWalletProperties);
    connect(ui_->createWalletButton, &QPushButton::clicked, this, &WalletsWidget::onNewWallet);
@@ -256,7 +257,8 @@ void WalletsWidget::InitWalletsView(const std::string& defaultWalletId)
    ui_->treeViewAddresses->setUniformRowHeights(true);
    ui_->treeViewAddresses->setModel(addressSortFilterModel_);
    ui_->treeViewAddresses->sortByColumn(2, Qt::DescendingOrder);
-   ui_->treeViewAddresses->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
+   ui_->treeViewWallets->header()->setSectionResizeMode(QHeaderView::Interactive);
+   ui_->treeViewWallets->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
    ui_->treeViewAddresses->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
    updateAddresses();


### PR DESCRIPTION
Issue: http://185.213.153.35:8081/browse/BST-2417
Change resize option for such tables as:
Overview → Non-settled transactions
Overview → Portfolio 
Trade → Trade blotter
Dealing → Trade blotter
Wallet → Wallet List
Wallet → Wallet details 

Notice: the changes was no done for ChatWidget, since general message conversation is not stored in AbstarctItemView