### PR TITLE
Fix network selection combobox while init first time

### DIFF
--- a/BlockSettleUILib/Settings/NetworkSettingsPage.cpp
+++ b/BlockSettleUILib/Settings/NetworkSettingsPage.cpp
@@ -117,6 +117,8 @@ void NetworkSettingsPage::display()
 
    displayArmorySettings();
    displayEnvironmentSettings();
+
+   disableSettingUpdate_ = false;
 }
 
 void NetworkSettingsPage::displayArmorySettings()
@@ -191,6 +193,10 @@ void NetworkSettingsPage::onEnvSelected(int index)
    ui_->spinBoxCustomPubBridgePort->setVisible(isCustom);
    ui_->labelCustomPubBridgeHost->setVisible(isCustom);
    ui_->labelCustomPubBridgePort->setVisible(isCustom);
+
+   if (disableSettingUpdate_) {
+      return;
+   }
 
    if (env == ApplicationSettings::EnvConfiguration::Production) {
       ui_->comboBoxArmoryServer->setCurrentIndex(armoryServersProvider_->getIndexOfMainNetServer());

--- a/BlockSettleUILib/Settings/NetworkSettingsPage.h
+++ b/BlockSettleUILib/Settings/NetworkSettingsPage.h
@@ -47,7 +47,7 @@ private slots:
 private:
    std::unique_ptr<Ui::NetworkSettingsPage> ui_;
    ArmoryServersViewModel *armoryServerModel_;
-   bool disableSettingUpdate_{false};
+   bool disableSettingUpdate_{true};
 };
 
 #endif // __NETWORK_SETTINGS_PAGE_H__


### PR DESCRIPTION
Issue:
network combobox in network settings is not updated properly.