### PR TITLE
Fix crash in auth addresses dialog when changing primary wallet

### DIFF
--- a/BlockSettleUILib/BSTerminalMainWindow.h
+++ b/BlockSettleUILib/BSTerminalMainWindow.h
@@ -173,7 +173,6 @@ private:
    std::shared_ptr<BSMarketDataProvider>     mdProvider_;
    std::shared_ptr<AssetManager>             assetManager_;
    std::shared_ptr<CCFileManager>            ccFileManager_;
-   std::shared_ptr<AuthAddressDialog>        authAddrDlg_;
    std::shared_ptr<WalletSignerContainer>    signContainer_;
    std::shared_ptr<AutoSignQuoteProvider>    autoSignQuoteProvider_;
 
@@ -259,6 +258,7 @@ private:
    bool wasWalletsRegistered_ = false;
    bool walletsSynched_ = false;
    bool isArmoryReady_ = false;
+   bool allowInitAuthAddr_ = false;
 
    std::unique_ptr<NetworkSettingsLoader> networkSettingsLoader_;
 


### PR DESCRIPTION
Issues: fix crash when changing auth addresses list

step to repro:
1. Login into terminal
2. Open auth address dialog(make sure that you have at least one auth adress)
3. Close dialog and delete primary wallet with auth leaf
4. Create new primary wallet
5. Open auth addresses dialog

Result : crash
Reason : model is not updated properly
Fix : create auth dialog in demand instead of saving pointer to it in memory. 