### PR TITLE
Change copy for primary wallet

### DIFF
--- a/BlockSettleUILib/BSTerminalMainWindow.cpp
+++ b/BlockSettleUILib/BSTerminalMainWindow.cpp
@@ -1807,10 +1807,10 @@ void BSTerminalMainWindow::promoteToPrimaryIfNeeded()
 
    auto promoteToPrimary = [this](const std::shared_ptr<bs::sync::hd::Wallet> &wallet) {
       addDeferredDialog([this, wallet] {
-         BSMessageBox qry(BSMessageBox::question, tr("Promote to primary wallet"), tr("Promote to primary wallet?")
+         BSMessageBox qry(BSMessageBox::question, tr("Upgrade wallet to enable trading"), tr("Upgrade wallet to enable trading?")
             , tr("To trade through BlockSettle, you are required to have a wallet which"
                " supports the sub-wallets required to interact with the system. Each Terminal"
-               " may only have one Primary Wallet. Do you wish to promote '%1'?")
+               " will only have one trading enabled wallet. Do you wish to upgrade your wallet?")
             .arg(QString::fromStdString(wallet->name())), this);
          if (qry.exec() == QDialog::Accepted) {
             walletsMgr_->PromoteHDWallet(wallet->walletId(), [this](bs::error::ErrorCode result) {


### PR DESCRIPTION
Issue: update copy for primary wallet creation, if we already have an primary wallet

Repro:
1. Create a primary wallet while no login and no ccgenfile presents
2. Login

Notice: we again propose to create primary wallet, even so our wallet is already primary