### PR TITLE
fix close button logic for wallet creation dialog

### DIFF
--- a/BlockSettleSigner/qml/BsDialogs/WalletCreateDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/WalletCreateDialog.qml
@@ -347,4 +347,9 @@ CustomTitleDialogWindow {
             }
         }
     }
+
+    function applyDialogClosing() {
+        JsHelper.openAbortBox(root, abortBoxType);
+        return false;
+    }
 }

--- a/BlockSettleSigner/qml/BsDialogs/WalletImportDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/WalletImportDialog.qml
@@ -642,4 +642,9 @@ CustomTitleDialogWindow {
             }
         }
     }
+
+    function applyDialogClosing() {
+        JsHelper.openAbortBox(root, abortBoxType);
+        return false;
+    }
 }

--- a/BlockSettleSigner/qml/BsDialogs/WalletNewSeedDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/WalletNewSeedDialog.qml
@@ -236,4 +236,9 @@ The backup is uncrypted and will allow anyone who holds it to recover the entire
             }
         }
     }
+
+    function applyDialogClosing() {
+        JsHelper.openAbortBox(root, abortBoxType);
+        return false;
+    }
 }

--- a/BlockSettleSigner/qml/StyledControls/CustomDialog.qml
+++ b/BlockSettleSigner/qml/StyledControls/CustomDialog.qml
@@ -71,6 +71,17 @@ CustomDialogWindow {
         else rejectAnimated()
     }
 
+    function hideMainWindow() {
+        if (applyDialogClosing()) {
+            rejectAnimated();
+        }
+    }
+
+    // override this function where needed
+    function applyDialogClosing() {
+        return true;
+    }
+
     property int animationDuration: 100
 
     default property alias cContentItem: customContentContainer.data

--- a/BlockSettleSigner/qml/js/helper.js
+++ b/BlockSettleSigner/qml/js/helper.js
@@ -64,8 +64,8 @@ function raiseWindow(w) {
 
 function hideWindow(w) {
     if ( w.hasOwnProperty("currentDialog") &&
-            (typeof w.currentDialog.rejectAnimated === "function")) {
-        w.currentDialog.rejectAnimated();
+            (typeof w.currentDialog.hideMainWindow === "function")) {
+        w.currentDialog.hideMainWindow();
         return;
     }
 
@@ -328,7 +328,9 @@ function prepareLiteModeDialog(dialog) {
 
     mainWindow.title = qsTr("BlockSettle Signer")
 
-    dialog.dialogsChainFinished.connect(function(){ hide() })
+    dialog.dialogsChainFinished.connect(function(){
+        hide();
+    })
     dialog.nextChainDialogChangedOverloaded.connect(function(nextDialog){
 //        if (typeof nextDialog.qmlTitleVisible !== "undefined") {
 //            nextDialog.qmlTitleVisible = false
@@ -378,6 +380,7 @@ function checkEncryptionPassword(dlg) {
         if (qmlFactory.controlPasswordStatus() === ControlPasswordStatus.RequestedNew) {
             walletsProxy.sendControlPassword(password)
             prevDialog.setNextChainDialog(dlg)
+            prepareDialog(dlg);
             dlg.open()
             return;
         }
@@ -389,6 +392,7 @@ function checkEncryptionPassword(dlg) {
             if (success) {
                 qmlFactory.setControlPasswordStatus(ControlPasswordStatus.Accepted);
                 prevDialog.setNextChainDialog(dlg)
+                prepareDialog(dlg);
                 dlg.open()
             } else {
                 let mbFail= messageBox(BSMessageBox.Type.Critical
@@ -408,8 +412,9 @@ function checkEncryptionPassword(dlg) {
         return controlPasswordDialog
     }
     else {
-        dlg.open()
-        return dlg
+        prepareDialog(dlg);
+        dlg.open();
+        return dlg;
     }
 }
 
@@ -424,6 +429,7 @@ function createNewWalletDialog(data) {
         var dlgCreateWallet = Qt.createComponent("../BsDialogs/WalletCreateDialog.qml").createObject(mainWindow)
         dlgNewSeed.setNextChainDialog(dlgCreateWallet)
         dlgCreateWallet.seed = newSeed
+        prepareDialog(dlgCreateWallet);
         dlgCreateWallet.open()
     })
 


### PR DESCRIPTION
Issues:
1. When creating(importing) wallet there is no possible to close dialog with close button(either when in chain with encryption wallet or when stand alone)

Expected behavior: in all cases we should show are you sure dialog like when we push cancel button 