### PR TITLE
Put value by copy into contact deferred lambda

### DIFF
--- a/BlockSettleUILib/BSTerminalMainWindow.cpp
+++ b/BlockSettleUILib/BSTerminalMainWindow.cpp
@@ -686,8 +686,8 @@ void BSTerminalMainWindow::tryInitChatView()
 
       connect(chatClientServicePtr_->getClientPartyModelPtr().get(), &Chat::ClientPartyModel::userPublicKeyChanged,
          this, [this](const Chat::UserPublicKeyInfoList& userPublicKeyInfoList) {
-         addDeferredDialog([this, &userPublicKeyInfoList]() {
-            ui_->widgetChat->onUserPublicKeyChanged(userPublicKeyInfoList);
+         addDeferredDialog([this, userPublicKeyList = userPublicKeyInfoList]() {
+            ui_->widgetChat->onUserPublicKeyChanged(userPublicKeyList);
          });
       }, Qt::QueuedConnection);
 


### PR DESCRIPTION
Issue: crash when importing user contacts list public key

Repro:
1. Import new wallet into brand new database.
2. Login.
3. Wait 5 seconds if you have only after import contacts list dialog popup
4. Agreed on it

Some time we have crash, since contacts list value was put by reference into deferred function