### PR TITLE
Delete manual guide reference

### DIFF
--- a/BlockSettleUILib/InfoDialogs/SupportDialog.ui
+++ b/BlockSettleUILib/InfoDialogs/SupportDialog.ui
@@ -6,9 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>526</width>
-    <height>400</height>
+    <width>400</width>
+    <height>350</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>400</width>
+    <height>350</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>400</width>
+    <height>350</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Support</string>
@@ -34,6 +46,9 @@
    </property>
    <item>
     <widget class="QStackedWidget" name="stackedWidget">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
      <widget class="QWidget" name="pageGuides">
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <property name="spacing">
@@ -96,11 +111,14 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <layout class="QGridLayout" name="gridLayout">
+            <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
+             <property name="horizontalSpacing">
+              <number>6</number>
+             </property>
              <property name="verticalSpacing">
               <number>20</number>
              </property>
-             <item row="1" column="0">
+             <item row="0" column="0">
               <widget class="QLabel" name="label">
                <property name="text">
                 <string/>
@@ -113,7 +131,26 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="1">
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_6">
+               <property name="maximumSize">
+                <size>
+                 <width>150</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;a href=&quot;https://pubb.blocksettle.com/PDF/Getting%20Started%20with%20Wallet.pdf&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#247dac;&quot;&gt;Getting Started with your BlockSettle Wallet&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+               <property name="openExternalLinks">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
               <widget class="QLabel" name="label_2">
                <property name="text">
                 <string/>
@@ -126,20 +163,26 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="2">
-              <widget class="QLabel" name="label_12">
-               <property name="text">
-                <string/>
+             <item row="2" column="0" colspan="2">
+              <widget class="Line" name="line">
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>1</height>
+                </size>
                </property>
-               <property name="pixmap">
-                <pixmap resource="../armory.qrc">:/resources/getstarted-manual@2x.png</pixmap>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>1</height>
+                </size>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
                </property>
               </widget>
              </item>
-             <item row="5" column="0" colspan="3">
+             <item row="3" column="0" colspan="2">
               <widget class="QWidget" name="widget_7" native="true">
                <property name="minimumSize">
                 <size>
@@ -188,71 +231,7 @@
                </layout>
               </widget>
              </item>
-             <item row="3" column="0" colspan="3">
-              <spacer name="verticalSpacer">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>50</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="0" column="0" colspan="3">
-              <spacer name="verticalSpacer_2">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>50</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="label_6">
-               <property name="maximumSize">
-                <size>
-                 <width>150</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="text">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;a href=&quot;https://pubb.blocksettle.com/PDF/Getting%20Started%20with%20Wallet.pdf&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#247dac;&quot;&gt;Getting Started with your BlockSettle Wallet&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-               <property name="openExternalLinks">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="2">
-              <widget class="QLabel" name="label_9">
-               <property name="maximumSize">
-                <size>
-                 <width>150</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="text">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;a href=&quot;https://pubb.blocksettle.com/PDF/BlockSettle%20Getting%20Started.pdf&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#247dac;&quot;&gt;Getting Started Manual&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-               <property name="openExternalLinks">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
+             <item row="1" column="1">
               <widget class="QLabel" name="label_8">
                <property name="maximumSize">
                 <size>
@@ -268,25 +247,6 @@
                </property>
                <property name="openExternalLinks">
                 <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="0" colspan="3">
-              <widget class="Line" name="line">
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>1</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>1</height>
-                </size>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
                </property>
               </widget>
              </item>
@@ -346,6 +306,12 @@
        <item>
         <widget class="QWidget" name="widget_6" native="true">
          <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>9</number>
+          </property>
           <item>
            <widget class="QWidget" name="verticalWidget_2" native="true">
             <property name="sizePolicy">
@@ -362,7 +328,7 @@
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_4">
              <property name="spacing">
-              <number>15</number>
+              <number>10</number>
              </property>
              <property name="leftMargin">
               <number>0</number>
@@ -386,6 +352,9 @@
                </property>
                <property name="alignment">
                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
                </property>
                <property name="openExternalLinks">
                 <bool>true</bool>
@@ -422,20 +391,10 @@
                <property name="text">
                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;OTC Chat&lt;/span&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;&lt;br/&gt;&lt;/span&gt;Ask the Community in the public chat room &lt;br/&gt;(Login to chat requires &lt;a href=&quot;https://blocksettle.com/auth-eid&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#247dac;&quot;&gt;Auth eID&lt;/span&gt;&lt;/a&gt;)&lt;/p&gt;&lt;p&gt;Someone from the BlockSettle team or the BlockSettle community will be happy to help.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
               </widget>
-             </item>
-             <item>
-              <spacer name="verticalSpacer_3">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>40</height>
-                </size>
-               </property>
-              </spacer>
              </item>
             </layout>
            </widget>
@@ -527,7 +486,7 @@
        <number>10</number>
       </property>
       <property name="rightMargin">
-       <number>5</number>
+       <number>10</number>
       </property>
       <property name="bottomMargin">
        <number>10</number>
@@ -551,6 +510,7 @@
   </layout>
  </widget>
  <resources>
+  <include location="../armory.qrc"/>
   <include location="../armory.qrc"/>
  </resources>
  <connections>


### PR DESCRIPTION
Issue: http://185.213.153.35:8081/browse/BST-2467

we do not need to show manual guide in guides dialog, only wallet guide and trading guide

Note: there is again issue with adding armory.qrc as resources twice, not sure why this issue is popup, but looks like it appears everywhere where we need armory.qrc support. So it's global issue somehow