### PR TITLE
Allow to show env combobox in production build

### DIFF
--- a/BlockSettleUILib/Settings/NetworkSettingsPage.cpp
+++ b/BlockSettleUILib/Settings/NetworkSettingsPage.cpp
@@ -114,10 +114,6 @@ NetworkSettingsPage::~NetworkSettingsPage() = default;
 
 void NetworkSettingsPage::display()
 {
-#ifdef PRODUCTION_BUILD
-   ui_->PublicBridgeSettingsGroup->hide();
-#endif
-
    displayArmorySettings();
    displayEnvironmentSettings();
 


### PR DESCRIPTION
Issue: http://185.213.153.35:8081/browse/BST-2469

Make possible to choose env in production build