### PR TITLE
Fix pdf content offset position while wallet creation

### DIFF
--- a/BlockSettleSigner/qml/BsDialogs/WalletNewSeedDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/WalletNewSeedDialog.qml
@@ -141,8 +141,7 @@ The backup is uncrypted and will allow anyone who holds it to recover the entire
                 }
 
                 Component.onCompleted: {
-                    // scroll to bottom
-                    contentItem.contentY = pdf.height - contentItem.height
+                    ScrollBar.vertical.position += 0.15
                 }
             }
         }


### PR DESCRIPTION
Issue: http://185.213.153.35:8081/browse/BST-2471

change content y position for pdf document when creating new wallet
