### PR TITLE
Add possibility to save empry encryption pass per session

### DIFF
--- a/BlockSettleSigner/qml/js/helper.js
+++ b/BlockSettleSigner/qml/js/helper.js
@@ -379,6 +379,7 @@ function checkEncryptionPassword(dlg) {
     var onControlPasswordFinished = function(prevDialog, password){
         if (qmlFactory.controlPasswordStatus() === ControlPasswordStatus.RequestedNew) {
             walletsProxy.sendControlPassword(password)
+            qmlFactory.setControlPasswordStatus(ControlPasswordStatus.Accepted);
             prevDialog.setNextChainDialog(dlg)
             prepareDialog(dlg);
             dlg.open()


### PR DESCRIPTION
Issue: http://185.213.153.35:8081/browse/BST-2470

Add possibility to set password in "set" state after we skip this wallet encryption in first place.
This rule is working per session.