### PR TITLE
[build] Fix packaging script on MacOS

### DIFF
--- a/Deploy/MacOSX/make_package.py
+++ b/Deploy/MacOSX/make_package.py
@@ -15,7 +15,7 @@ def generate_project(sourcesRoot, productionBuild):
    command.append('release')
 
    if productionBuild:
-      command.append('-production')
+      command.append('--production')
 
    result = subprocess.call(command, cwd=sourcesRoot)
    return result == 0


### PR DESCRIPTION
generate.py now uses --production not "-production".