### PR TITLE
Disable showing hint label in FX dialog

### DIFF
--- a/BlockSettleUILib/Trading/RequestingQuoteWidget.cpp
+++ b/BlockSettleUILib/Trading/RequestingQuoteWidget.cpp
@@ -259,8 +259,10 @@ void RequestingQuoteWidget::onAccept()
    requestTimer_.stop();
    ui_->progressBar->hide();
    ui_->pushButtonAccept->setEnabled(false);
-   ui_->labelHint->setText(tr("Awaiting Settlement Pay-Out Execution"));
-   ui_->labelHint->show();
+   if (bs::network::Asset::SpotFX != rfq_.assetType) {
+      ui_->labelHint->setText(tr("Awaiting Settlement Pay-Out Execution"));
+      ui_->labelHint->show();
+   }
 
    emit quoteAccepted(QString::fromStdString(rfq_.requestId), quote_);
 }


### PR DESCRIPTION
Issue:
for a short period of time we could see label "Awaiting Settlement Pay-Out Execution" in terminal dialog which is should not be possible for FX market

http://185.213.153.35:8081/browse/BST-2476