### PR TITLE
Force to refresh wallets after get a sync commands from signer app

### DIFF
--- a/BlockSettleSigner/HeadlessApp.cpp
+++ b/BlockSettleSigner/HeadlessApp.cpp
@@ -328,8 +328,12 @@ void HeadlessAppObj::stopTerminalsProcessing()
 void HeadlessAppObj::applyNewControlPassword(const SecureBinaryData &controlPassword, bool notifyGui)
 {
    controlPassword_ = controlPassword;
+   auto prevControlPassStatus = controlPasswordStatus_;
    reloadWallets(notifyGui);
-   guiListener_->walletsListUpdated();
+   if (prevControlPassStatus != controlPasswordStatus_ && controlPasswordStatus_ == signer::Accepted) {
+      guiListener_->onStarted();
+      terminalListener_->syncWallet();
+   }
 }
 
 SecureBinaryData HeadlessAppObj::controlPassword() const

--- a/BlockSettleUILib/BSTerminalMainWindow.cpp
+++ b/BlockSettleUILib/BSTerminalMainWindow.cpp
@@ -368,9 +368,6 @@ void BSTerminalMainWindow::LoadWallets()
 {
    logMgr_->logger()->debug("Loading wallets");
 
-   wasWalletsRegistered_ = false;
-   walletsSynched_ = false;
-
    connect(walletsMgr_.get(), &bs::sync::WalletsManager::walletsReady, this, [this] {
       ui_->widgetRFQ->setWalletsManager(walletsMgr_);
       ui_->widgetRFQReply->setWalletsManager(walletsMgr_);
@@ -393,11 +390,8 @@ void BSTerminalMainWindow::LoadWallets()
    connect(walletsMgr_.get(), &bs::sync::WalletsManager::newWalletAdded, this
       , &BSTerminalMainWindow::updateControlEnabledState);
 
-   const auto &progressDelegate = [this](int cur, int total) {
-      logMgr_->logger()->debug("Loaded wallet {} of {}", cur, total);
-   };
    walletsMgr_->reset();
-   walletsMgr_->syncWallets(progressDelegate);
+   onSyncWallets();
 }
 
 void BSTerminalMainWindow::InitAuthManager()
@@ -541,6 +535,7 @@ bool BSTerminalMainWindow::InitSigningContainer()
    walletsMgr_->setSignContainer(signContainer_);
    connect(signContainer_.get(), &WalletSignerContainer::ready, this, &BSTerminalMainWindow::SignerReady, Qt::QueuedConnection);
    connect(signContainer_.get(), &WalletSignerContainer::needNewWalletPrompt, this, &BSTerminalMainWindow::onNeedNewWallet, Qt::QueuedConnection);
+   connect(signContainer_.get(), &WalletSignerContainer::walletsReadyToSync, this, &BSTerminalMainWindow::onSyncWallets, Qt::QueuedConnection);
 
    return true;
 }
@@ -1736,6 +1731,16 @@ void BSTerminalMainWindow::onTabWidgetCurrentChanged(const int &index)
    const int chatIndex = ui_->tabWidget->indexOf(ui_->widgetChat);
    const bool isChatTab = index == chatIndex;
    //ui_->widgetChat->updateChat(isChatTab);
+}
+
+void BSTerminalMainWindow::onSyncWallets()
+{
+   wasWalletsRegistered_ = false;
+   walletsSynched_ = false;
+   const auto &progressDelegate = [this](int cur, int total) {
+      logMgr_->logger()->debug("Loaded wallet {} of {}", cur, total);
+   };
+   walletsMgr_->syncWallets(progressDelegate);
 }
 
 void BSTerminalMainWindow::InitWidgets()

--- a/BlockSettleUILib/BSTerminalMainWindow.h
+++ b/BlockSettleUILib/BSTerminalMainWindow.h
@@ -148,6 +148,7 @@ private slots:
    void onCCLoaded();
 
    void onTabWidgetCurrentChanged(const int &index);
+   void onSyncWallets();
 
 private:
    std::unique_ptr<Ui::BSTerminalMainWindow> ui_;


### PR DESCRIPTION
Issue: fix wallet rapidly growing in DB when login
Note: this review is depend on https://github.com/BlockSettle/common/pull/1758

Description: http://185.213.153.35:8081/browse/BST-2434
In this PR we fixed one of the underlying issue which is causing wallet to growth in the first place.
So this is preventive fix before main fix where will be created and new thread for wallet loading from disk. 

Repro:
1. Import wallet, and set encryption password
2. Continue restart terminal with entering encryption again and again and notice how increasing time of wallet appears in terminal + how is growing size of db data storage on disk `blocksettle\testnet3\signer`
