### PR TITLE
Disable to create Buy RFQ if counter currency is emoty

### DIFF
--- a/BlockSettleUILib/Trading/RFQTicketXBT.cpp
+++ b/BlockSettleUILib/Trading/RFQTicketXBT.cpp
@@ -559,11 +559,13 @@ bs::Address RFQTicketXBT::recvXbtAddressIfSet() const
 
 bool RFQTicketXBT::checkBalance(double qty) const
 {
-   if (getSelectedSide() == bs::network::Side::Buy) {
-      return true;
-   }
    const auto balance = getBalanceInfo();
-   return (qty <= balance.amount);
+   if (getSelectedSide() == bs::network::Side::Buy) {
+      return (balance.amount > 0);
+   }
+   else {
+      return (qty <= balance.amount);
+   }
 }
 
 void RFQTicketXBT::updateSubmitButton()


### PR DESCRIPTION
Repro:
1. In trade tab choose currency with zero amount(for example EUR/USD and USD amount is equal to zero).
2. Chose EUR and Buy operation.
3. Notice that after we enter value is still possible to trade, even so we have zero balance and it not possible to but anything.
4. Also it will show insufficient balance, once we start trading and some one quote this RFQ.

Expected: we will not give possibility to press submit bitton