### PR TITLE
Increase height of seed wallet dialog to avoid clipping control buttons

### DIFF
--- a/BlockSettleSigner/qml/BsDialogs/WalletNewSeedDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/WalletNewSeedDialog.qml
@@ -44,7 +44,7 @@ CustomTitleDialogWindow {
     }
 
     function calcHeight(page) {
-        return page === 1 ? (fullScreenMode ? 800 : mainWindow.height * 0.98) : 260
+        return page === 1 ? (fullScreenMode ? 800 : mainWindow.height * 0.98) : 280
     }
 
     abortConfirmation: true


### PR DESCRIPTION
Issue: Increase height of seed wallet dialog to avoid clipping control buttons

Repro:
1. Start terminal on linux
2. Start creating new wallet
3. Notice when we jump on second dialog where we need to enter seed, there is clipped control buttons layout.