### PR TITLE
Disable to show error message about timeout when signing auth eid

### DIFF
--- a/BlockSettleSigner/AuthProxy.cpp
+++ b/BlockSettleSigner/AuthProxy.cpp
@@ -60,9 +60,8 @@ void AuthSignWalletObject::connectToServer()
    connect(autheIDClient_.get(), &AutheIDClient::failed, this, [this](AutheIDClient::ErrorType authError){
       emit failed(AutheIDClient::errorString(authError));
    });
-   connect(autheIDClient_.get(), &AutheIDClient::userCancelled, this, [this](){
-      emit userCancelled();
-   });
+   connect(autheIDClient_.get(), &AutheIDClient::userCancelled, this, &AuthSignWalletObject::userCancelled);
+   connect(autheIDClient_.get(), &AutheIDClient::canceledByTimeout, this, &AuthSignWalletObject::canceledByTimeout);
 }
 
 void AuthSignWalletObject::signWallet(AutheIDClient::RequestType requestType, bs::hd::WalletInfo *walletInfo,

--- a/BlockSettleSigner/AuthProxy.h
+++ b/BlockSettleSigner/AuthProxy.h
@@ -61,7 +61,7 @@ signals:
    void succeeded(const QString &encKey, const SecureBinaryData &password) const;
    void failed(const QString &text) const;
    void userCancelled() const;
-
+   void canceledByTimeout() const;
 
 public:
    QString status() const { return status_; }

--- a/BlockSettleSigner/qml/BsControls/BSPasswordInput.qml
+++ b/BlockSettleSigner/qml/BsControls/BSPasswordInput.qml
@@ -67,7 +67,10 @@ BSWalletHandlerDialog {
             showWalletError(errorText);
         })
         authSign.userCancelled.connect(function() {
-            rejectAnimated();
+            rejectWithNoError();
+        })
+        authSign.canceledByTimeout.connect(function() {
+            rejectWithNoError();
         })
     }
 
@@ -160,7 +163,7 @@ BSWalletHandlerDialog {
                         timeLeft -= 0.5
                         if (timeLeft <= 0) {
                             stop()
-                            showWalletError(kOperationTimeExceeded);
+                            rejectWithNoError();
                         }
                     }
                     signal expired()

--- a/BlockSettleSigner/qml/BsControls/BSWalletHandlerDialog.qml
+++ b/BlockSettleSigner/qml/BsControls/BSWalletHandlerDialog.qml
@@ -19,19 +19,35 @@ CustomTitleDialogWindow {
     id: root
 
     property bool rejectedDialogWasShown: false
-    readonly property string kOperationTimeExceeded : qsTr("Operation time exceeded")
 
     function showWalletError(errorText) {
-        if (root.rejectedDialogWasShown) {
+        if (checkShownFlag()) {
             return;
         }
 
-        root.rejectedDialogWasShown = true;
         var mb = JsHelper.messageBox(BSMessageBox.Type.Critical
             , qsTr("Wallet"), errorText
             , qsTr("Wallet Name: %1\nWallet ID: %2").arg(walletInfo.name).arg(walletInfo.rootId))
         mb.bsAccepted.connect(function() { root.rejectAnimated() })
         root.setNextChainDialog(mb);
+    }
+
+    function rejectWithNoError() {
+        if (checkShownFlag()) {
+            return;
+        }
+
+        root.rejectedDialogWasShown = true;
+        root.rejectAnimated();
+    }
+
+    function checkShownFlag() {
+        if (root.rejectedDialogWasShown) {
+            return true;
+        }
+
+        root.rejectedDialogWasShown = true;
+        return false;
     }
 }
 

--- a/BlockSettleSigner/qml/BsDialogs/TxSignDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/TxSignDialog.qml
@@ -66,7 +66,10 @@ BSWalletHandlerDialog {
             showWalletError(errorText);
         })
         authSign.userCancelled.connect(function() {
-            rejectAnimated()
+            rejectWithNoError();
+        })
+        authSign.canceledByTimeout.connect(function() {
+            rejectWithNoError();
         })
     }
 
@@ -297,7 +300,7 @@ BSWalletHandlerDialog {
                     timeLeft -= 0.5
                     if (timeLeft <= 0) {
                         stop()
-                        showWalletError(kOperationTimeExceeded);
+                        rejectWithNoError();
                     }
                 }
                 signal expired()

--- a/BlockSettleSigner/qml/BsDialogs/TxSignSettlementBaseDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/TxSignSettlementBaseDialog.qml
@@ -121,15 +121,11 @@ CustomTitleDialogWindowWithExpander {
                 root.acceptAnimated()
             }
         });
-        authSign.failed.connect(function(errorText) {
-            if (root) {
-                showWalletError(errorText);
-            }
-        })
         authSign.userCancelled.connect(function() {
-            if (root) {
-                root.rejectAnimated()
-            }
+            if (root) rejectWithNoError();
+        })
+        authSign.canceledByTimeout.connect(function() {
+            if (root) rejectWithNoError();
         })
     }
 
@@ -441,8 +437,7 @@ CustomTitleDialogWindowWithExpander {
                         timeLeft -= 0.5
                         if (timeLeft <= 0) {
                             stop()
-                            // assume non signed tx is cancelled tx
-                            showWalletError(kOperationTimeExceeded);
+                            rejectWithNoError();
                         }
                     }
                     signal expired()

--- a/BlockSettleSigner/qml/js/helper.js
+++ b/BlockSettleSigner/qml/js/helper.js
@@ -115,6 +115,11 @@ function requesteIdAuth (requestType, walletInfo, authEidMessage, onSuccess) {
         authProgress.rejectAnimated()
         authObject.destroy()
     })
+    authObject.canceledByTimeout.connect(function() {
+        console.log("QML requesteIdAuth: authObject.canceledByTimeout")
+        authProgress.rejectAnimated()
+        authObject.destroy()
+    })
 
     return authProgress
 }


### PR DESCRIPTION
Issue: do not show error dialog when auth eid sign transaction is ending by timeout

Note: this PR depends on https://github.com/BlockSettle/common/pull/1776

Repro:
1. Create auth eid wallet
2. Create tx(start trading on XBT)
3. Do not sign transaction.

Notice how in the end we show error dialog with time exceed message

Wanted: just close sign dialog by timeout 

