### PR TITLE
Fix parent relation for AQ script object

### DIFF
--- a/BlockSettleUILib/UserScriptRunner.cpp
+++ b/BlockSettleUILib/UserScriptRunner.cpp
@@ -28,8 +28,10 @@ UserScriptHandler::UserScriptHandler(std::shared_ptr<QuoteProvider> quoteProvide
    std::shared_ptr<MarketDataProvider> mdProvider,
    std::shared_ptr<AssetManager> assetManager,
    std::shared_ptr<spdlog::logger> logger,
-   UserScriptRunner *runner)
-   : signingContainer_(signingContainer)
+   UserScriptRunner *runner,
+   QThread *handlerThread)
+   : QObject(handlerThread)
+   , signingContainer_(signingContainer)
    , mdProvider_(mdProvider)
    , assetManager_(assetManager)
    , logger_(logger)
@@ -310,7 +312,7 @@ UserScriptRunner::UserScriptRunner(std::shared_ptr<QuoteProvider> quoteProvider,
    : QObject(parent)
    , thread_(new QThread(this))
    , script_(new UserScriptHandler(quoteProvider, signingContainer,
-         mdProvider, assetManager, logger, this))
+         mdProvider, assetManager, logger, this, thread_))
 
    , logger_(logger)
 {
@@ -327,7 +329,6 @@ UserScriptRunner::UserScriptRunner(std::shared_ptr<QuoteProvider> quoteProvider,
 
 UserScriptRunner::~UserScriptRunner() noexcept
 {
-   script_->deleteLater();
    thread_->quit();
    thread_->wait();
 }

--- a/BlockSettleUILib/UserScriptRunner.h
+++ b/BlockSettleUILib/UserScriptRunner.h
@@ -58,7 +58,8 @@ public:
       std::shared_ptr<MarketDataProvider> mdProvider,
       std::shared_ptr<AssetManager> assetManager,
       std::shared_ptr<spdlog::logger> logger,
-      UserScriptRunner *runner);
+      UserScriptRunner *runner,
+      QThread *handlerThread);
    ~UserScriptHandler() noexcept override;
 
    void setWalletsManager(const std::shared_ptr<bs::sync::WalletsManager> &);


### PR DESCRIPTION
Issue: fix incorrect timer deletion handling in concurrent thread for UserScriptHandler

Repro:
1. Start terminal
2. Login
3. Enable any auto quoting script
4. Exit terminal

Result: terminal crash
Expected result: normal exit with no error

Reason: Qt rule - we cannot stop timer from different thread, as result we do not set parent for AQ script and trying to stop timer from main thread which is lead to crash.