### PR TITLE
Clear best quote label when reject all quotes signal arrived

### DIFF
--- a/BlockSettleUILib/Trading/QuoteRequestsModel.cpp
+++ b/BlockSettleUILib/Trading/QuoteRequestsModel.cpp
@@ -704,6 +704,24 @@ void QuoteRequestsModel::onQuoteNotifCancelled(const QString &reqId)
    }
 }
 
+void QuoteRequestsModel::onAllQuoteNotifCancelled(const QString &reqId)
+{
+   int row = -1;
+   RFQ *rfq = nullptr;
+
+   forSpecificId(reqId.toStdString(), [&](Group *group, int i) {
+      row = i;
+      rfq = group->rfqs_[static_cast<std::size_t>(i)].get();
+      rfq->bestQuotedPxString_.clear();
+   });
+
+   if (row >= 0 && rfq) {
+      static const QVector<int> roles({ Qt::DisplayRole });
+      const QModelIndex idx = createIndex(row, static_cast<int>(Column::BestPx), &rfq->idx_);
+      emit dataChanged(idx, idx, roles);
+   }
+}
+
 void QuoteRequestsModel::onQuoteReqCancelled(const QString &reqId, bool byUser)
 {
    if (!byUser) {

--- a/BlockSettleUILib/Trading/QuoteRequestsModel.h
+++ b/BlockSettleUILib/Trading/QuoteRequestsModel.h
@@ -124,6 +124,7 @@ public:
 public:
    void onQuoteReqNotifReplied(const bs::network::QuoteNotification &qn);
    void onQuoteNotifCancelled(const QString &reqId);
+   void onAllQuoteNotifCancelled(const QString &reqId);
    void onQuoteReqCancelled(const QString &reqId, bool byUser);
    void onQuoteRejected(const QString &reqId, const QString &reason);
    void onSecurityMDUpdated(const QString &security, const bs::network::MDFields &);

--- a/BlockSettleUILib/Trading/QuoteRequestsWidget.cpp
+++ b/BlockSettleUILib/Trading/QuoteRequestsWidget.cpp
@@ -202,6 +202,13 @@ void QuoteRequestsWidget::onQuoteNotifCancelled(const QString &reqId)
    }
 }
 
+void QuoteRequestsWidget::onAllQuoteNotifCancelled(const QString &reqId)
+{
+   if (model_) {
+      model_->onAllQuoteNotifCancelled(reqId);
+   }
+}
+
 void QuoteRequestsWidget::onQuoteReqCancelled(const QString &reqId, bool byUser)
 {
    if (model_) {

--- a/BlockSettleUILib/Trading/QuoteRequestsWidget.h
+++ b/BlockSettleUILib/Trading/QuoteRequestsWidget.h
@@ -141,6 +141,7 @@ public slots:
    void onQuoteReqNotifReplied(const bs::network::QuoteNotification &);
    void onQuoteReqNotifSelected(const QModelIndex& index);
    void onQuoteNotifCancelled(const QString &reqId);
+   void onAllQuoteNotifCancelled(const QString &reqId);
    void onQuoteReqCancelled(const QString &reqId, bool byUser);
    void onQuoteRejected(const QString &reqId, const QString &reason);
    void onSecurityMDUpdated(bs::network::Asset::Type, const QString &security, bs::network::MDFields);

--- a/BlockSettleUILib/Trading/RFQReplyWidget.cpp
+++ b/BlockSettleUILib/Trading/RFQReplyWidget.cpp
@@ -184,6 +184,7 @@ void RFQReplyWidget::init(const std::shared_ptr<spdlog::logger> &logger
    connect(quoteProvider_.get(), &QuoteProvider::quoteRejected, ui_->widgetQuoteRequests, &QuoteRequestsWidget::onQuoteRejected);
 
    connect(quoteProvider_.get(), &QuoteProvider::quoteNotifCancelled, ui_->widgetQuoteRequests, &QuoteRequestsWidget::onQuoteNotifCancelled);
+   connect(quoteProvider_.get(), &QuoteProvider::allQuoteNotifCancelled, ui_->widgetQuoteRequests, &QuoteRequestsWidget::onAllQuoteNotifCancelled);
    connect(quoteProvider_.get(), &QuoteProvider::signTxRequested, this, &RFQReplyWidget::onSignTxRequested);
 
    ui_->treeViewOrders->header()->setSectionResizeMode(QHeaderView::ResizeToContents);


### PR DESCRIPTION
Issue: after quoting on RFQ(assuming we only person who is trading in the moment) and pulling our proposal terminal is not updating best quote price

This issue is related on https://github.com/BlockSettle/common/pull/1780