### PR TITLE
Do not allow quote on rfq which was withdrawn

### DIFF
--- a/BlockSettleUILib/Trading/QuoteRequestsModel.h
+++ b/BlockSettleUILib/Trading/QuoteRequestsModel.h
@@ -222,6 +222,7 @@ private:
       IndexHelper idx_;
       bool quoted_;
       bool visible_;
+      bool withdrawn_ = false;
 
       RFQ()
          : idx_(nullptr, this, DataType::RFQ)

--- a/BlockSettleUILib/Trading/QuoteRequestsWidget.cpp
+++ b/BlockSettleUILib/Trading/QuoteRequestsWidget.cpp
@@ -474,27 +474,28 @@ bool QuoteReqSortModel::filterAcceptsRow(int row, const QModelIndex &parent) con
 {
    const auto index = sourceModel()->index(row, 0, parent);
 
-   if (index.isValid() ) {
-      if(index.data(static_cast<int>(QuoteRequestsModel::Role::Type)).toInt() ==
-         static_cast<int>(QuoteRequestsModel::DataType::RFQ)) {
-            if (parent.data(static_cast<int>(QuoteRequestsModel::Role::LimitOfRfqs)).toInt() > 0) {
-               if (index.data(static_cast<int>(QuoteRequestsModel::Role::Visible)).toBool()) {
-                  return true;
-               } else if (index.data(static_cast<int>(QuoteRequestsModel::Role::Quoted)).toBool() &&
-                     showQuoted_) {
-                        return true;
-               } else {
-                  return false;
-               }
-            } else {
-               return true;
-            }
-      } else {
-         return true;
-      }
-   } else {
+   if (!index.isValid()) {
       return false;
    }
+
+   if (index.data(static_cast<int>(QuoteRequestsModel::Role::Type)).toInt() !=
+      static_cast<int>(QuoteRequestsModel::DataType::RFQ)) {
+      return true;
+   }
+
+   if (parent.data(static_cast<int>(QuoteRequestsModel::Role::LimitOfRfqs)).toInt() <= 0) {
+      return true;
+   }
+
+   if (index.data(static_cast<int>(QuoteRequestsModel::Role::Visible)).toBool()) {
+      return true;
+   }
+   else if (index.data(static_cast<int>(QuoteRequestsModel::Role::Quoted)).toBool() &&
+      showQuoted_) {
+      return true;
+   }
+
+   return false;
 }
 
 void QuoteReqSortModel::showQuoted(bool on)


### PR DESCRIPTION
Issue: while fast competitive trading there is possible situation when AQ quote is triggering just after withdraw is receiving

Repro(the best possibility on debug mode):
1. Start 3 terminals, enable auto quoting on two of them.
2. Create 5 RFQ in third terminal.
3. Reject all 5 RFQs.
4. Check "Quote request blotter" in dealing tab on terminals where auto quoting are enabled.
5. There could be some of quotes that are not disappear after withdrawn.
6. If there everything clean, repeat steps 1-5.

