### PR TITLE
Fix TransactionsViewModel::onRefreshTxValidity

### DIFF
--- a/BlockSettleUILib/TransactionsViewModel.cpp
+++ b/BlockSettleUILib/TransactionsViewModel.cpp
@@ -330,7 +330,7 @@ void TransactionsViewModel::loadAllWallets(bool onNewBlock)
 
 int TransactionsViewModel::columnCount(const QModelIndex &) const
 {
-   return static_cast<int>(Columns::last);
+   return static_cast<int>(Columns::last) + 1;
 }
 
 TXNode *TransactionsViewModel::getNode(const QModelIndex &index) const

--- a/BlockSettleUILib/TransactionsViewModel.h
+++ b/BlockSettleUILib/TransactionsViewModel.h
@@ -205,7 +205,7 @@ public:
 //      MissedBlocks,
       Comment,
       TxHash,
-      last
+      last = TxHash
    };
 
    enum Role {


### PR DESCRIPTION
`Columns::last` was not last really, it was last + 1 and so this line did not work properly:
```
         emit dataChanged(index(i, static_cast<int>(Columns::first))
         , index(i, static_cast<int>(Columns::last)));
```