### PR TITLE
BST-2577: fixed another #addr hardcoded value

### DIFF
--- a/BlockSettleUILib/WalletsViewModel.cpp
+++ b/BlockSettleUILib/WalletsViewModel.cpp
@@ -72,7 +72,7 @@ public:
             case WalletsViewModel::WalletRegColumns::ColumnState:
                return getState();
             case WalletsViewModel::WalletRegColumns::ColumnNbAddresses:
-               return nbAddr_ ? QString::number(std::max(static_cast<size_t>(5), nbAddr_)) : QString();
+               return nbAddr_ ? QString::number(nbAddr_) : QString();
             default:
                return QVariant();
             }


### PR DESCRIPTION
I wonder, who and why was putting these `std::max(5, nbAddr_)` values?