### PR TITLE
Fix small qml mistakes

### DIFF
--- a/BlockSettleSigner/qml/BsControls/BSEidProgressBox.qml
+++ b/BlockSettleSigner/qml/BsControls/BSEidProgressBox.qml
@@ -33,7 +33,6 @@ CustomTitleDialogWindow {
     }
 
     width: 350
-    height: 210 + headerPanelHeight
 
     title: qsTr("Sign with Auth eID")
 

--- a/BlockSettleSigner/qml/BsControls/BSMessageBox.qml
+++ b/BlockSettleSigner/qml/BsControls/BSMessageBox.qml
@@ -42,7 +42,6 @@ CustomTitleDialogWindow {
        Critical = 4
     }
     width: 350
-    //height: 70 + headerPanelHeight + contentItemData.height
     acceptable: true
     rejectable: true
 

--- a/BlockSettleSigner/qml/BsDialogs/WalletImportDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/WalletImportDialog.qml
@@ -73,9 +73,6 @@ CustomTitleDialogWindow {
         }
     }
 
-    onAboutToShow: hwDeviceList.init()
-    onAboutToHide: hwDeviceList.release();
-
     onEnterPressed: {
         if (btnAccept.enabled) btnAccept.onClicked()
     }

--- a/BlockSettleSigner/qml/BsDialogs/WalletImportHwDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/WalletImportHwDialog.qml
@@ -119,7 +119,7 @@ CustomTitleDialogWindow {
                             Layout.fillWidth: true
                             text: qsTr(
                              "No hardware device detected.\n" +
-                             "If your device cannot be detected, please consider the following steps before consulting your hardware wallet manufacturer:\n" +
+                             "If your device cannot be detected, please consider the following steps before consulting your hardware wallet manufacturer:\n\n" +
                              "• If you are a Linux user, your device must be added to udev rule to make possible to communicate with it. Please make sure device is detected correctly on system.\n" +
                              "• If you are a Trezor user, ensure you have the Trezor Bridge installed (if not install and press \"Rescan\")\n" +
                              "• If you are a Ledger user, ensure your PIN has been entered and that your device displays \"Application is Ready\"")


### PR DESCRIPTION
Issues:
1. Error log about init device manager while start non hw import
2. Auth sign dialog was broken when import new wallet -> choose auth eid & start send sign request to phone -> dialog with 120 seconds timer broken.
3. Make extra space in no hw device detected message