### PR TITLE
Fix TestAuth

### DIFF
--- a/UnitTests/TestAuth.cpp
+++ b/UnitTests/TestAuth.cpp
@@ -180,12 +180,12 @@ void TestAuth::SetUp()
    {
       //first UTXO, should remain untouched until validation address 
       //is revoked
-      auto&& hash = sendTo(50 * COIN, validationAddr_);
+      auto&& hash = sendTo(10 * COIN, validationAddr_);
       actPtr_->waitOnZC(hash);
       mineBlocks(1);
 
       //actual spendable UTXO for vetting user auth addresses
-      hash = sendTo(300 * COIN, validationAddr_);
+      hash = sendTo(10 * COIN, validationAddr_);
       actPtr_->waitOnZC(hash);
       mineBlocks(6);
    }
@@ -550,11 +550,11 @@ TEST_F(TestAuth, Revoke)
    {
       //first UTXO, should remain untouched until validation address 
       //is revoked
-      sendTo(50 * COIN, validationAddr2);
+      sendTo(10 * COIN, validationAddr2);
       mineBlocks(1);
 
       //actual spendable UTXO for vetting user auth addresses
-      sendTo(300 * COIN, validationAddr2);
+      sendTo(10 * COIN, validationAddr2);
       mineBlocks(6);
    }
 
@@ -847,13 +847,13 @@ TEST_F(TestAuth, Concurrency)
    {
       //first UTXO, should remain untouched until validation address 
       //is revoked
-      sendTo(50 * COIN, validationAddr2);
-      sendTo(50 * COIN, validationAddr3);
+      sendTo(10 * COIN, validationAddr2);
+      sendTo(10 * COIN, validationAddr3);
       mineBlocks(1);
 
       //actual spendable UTXO for vetting user auth addresses
-      sendTo(300 * COIN, validationAddr2);
-      sendTo(300 * COIN, validationAddr3);
+      sendTo(10 * COIN, validationAddr2);
+      sendTo(10 * COIN, validationAddr3);
       mineBlocks(6);
    }
 
@@ -1062,13 +1062,13 @@ TEST_F(TestAuth, Concurrency_WithACT)
    {
       //first UTXO, should remain untouched until validation address 
       //is revoked
-      sendTo(50 * COIN, validationAddr2);
-      sendTo(50 * COIN, validationAddr3);
+      sendTo(10 * COIN, validationAddr2);
+      sendTo(10 * COIN, validationAddr3);
       mineBlocks(1);
 
       //actual spendable UTXO for vetting user auth addresses
-      sendTo(300 * COIN, validationAddr2);
-      sendTo(300 * COIN, validationAddr3);
+      sendTo(10 * COIN, validationAddr2);
+      sendTo(10 * COIN, validationAddr3);
       mineBlocks(6);
    }
 


### PR DESCRIPTION
Looks like TestAuth was broken for some time.
TestAuth::sendTo was called with value set to 300 * COIN when used UTXO contained 50 * COIN.
Recent ArmoryDB update added checks in Signer::sign that caused TestAuth to fail.