### PR TITLE
[WIP] Fix to disallow create legacy change address

### DIFF
--- a/BlockSettleUILib/CreateTransactionDialog.h
+++ b/BlockSettleUILib/CreateTransactionDialog.h
@@ -94,7 +94,8 @@ protected:
    virtual QLabel* changeLabel() const {return nullptr; }
 
    using AddressCb = std::function<void(const bs::Address&)>;
-   virtual void getChangeAddress(AddressCb) const = 0;
+   using AddressFullCb = std::function<void(const bs::Address&, const std::string&)>;
+   virtual void getChangeAddress(AddressFullCb) const = 0;
 
    virtual void onTransactionUpdated();
 

--- a/BlockSettleUILib/CreateTransactionDialogAdvanced.h
+++ b/BlockSettleUILib/CreateTransactionDialogAdvanced.h
@@ -101,7 +101,7 @@ protected:
    virtual QLabel *changeLabel() const override;
 
    void onTransactionUpdated() override;
-   void getChangeAddress(AddressCb cb) const override;
+   void getChangeAddress(AddressFullCb cb) const override;
 
    bool HaveSignedImportedTransaction() const override;
 

--- a/BlockSettleUILib/CreateTransactionDialogSimple.cpp
+++ b/BlockSettleUILib/CreateTransactionDialogSimple.cpp
@@ -180,15 +180,15 @@ void CreateTransactionDialogSimple::showAdvanced()
    accept();
 }
 
-void CreateTransactionDialogSimple::getChangeAddress(AddressCb cb) const
+void CreateTransactionDialogSimple::getChangeAddress(AddressFullCb cb) const
 {
    if (transactionData_->GetTransactionSummary().hasChange) {
       transactionData_->getWallet()->getNewChangeAddress([cb = std::move(cb)](const bs::Address &addr) {
-         cb(addr);
+         cb(addr, {});
       });
       return;
    }
-   cb({});
+   cb({}, {});
 }
 
 void CreateTransactionDialogSimple::createTransaction()

--- a/BlockSettleUILib/CreateTransactionDialogSimple.h
+++ b/BlockSettleUILib/CreateTransactionDialogSimple.h
@@ -61,7 +61,7 @@ protected:
    QLabel* labelTXAmount() const override;
    QLabel* labelTxOutputs() const override;
 
-   void getChangeAddress(AddressCb cb) const override;
+   void getChangeAddress(AddressFullCb cb) const override;
 
 protected slots:
    void onMaxPressed() override;


### PR DESCRIPTION
Issue: when we making tx where input is legacy, the change address crating as legacy as well, even so we could specify only segwit change address type.
