### PR TITLE
Separated hw leaf

### DIFF
--- a/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationRequestWidget.cpp
+++ b/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationRequestWidget.cpp
@@ -177,23 +177,13 @@ void OTCNegotiationRequestWidget::onSubmited()
       return;
    }
 
-   const auto hdWallet = getCurrentHDWalletFromCombobox(ui_->comboBoxXBTWallets);
-   if (!hdWallet) {
-      return;
-   }
-
-   auto cbUtxoSet = [wdgt = QPointer<OTCNegotiationRequestWidget>(this)](std::vector<UTXO>&& utxos) {
-      if (!wdgt) {
+   submitProposal(ui_->comboBoxXBTWallets, bs::XBTAmount(ui_->quantitySpinBox->value()),
+      [caller = QPointer<OTCNegotiationRequestWidget>(this)]() {
+      if (!caller) {
          return;
       }
-
-      wdgt->setSelectedInputs(utxos);
-      wdgt->setReservation(wdgt->getUtxoManager()->makeNewReservation(utxos));
-      emit wdgt->requestCreated();
-   };
-
-   getUtxoManager()->getBestXbtUtxoSet(hdWallet->walletId(), bs::XBTAmount(ui_->quantitySpinBox->value()).GetValue()
-      , std::move(cbUtxoSet), true);
+      caller->requestCreated();
+   });
 }
 
 std::shared_ptr<bs::sync::hd::Wallet> OTCNegotiationRequestWidget::getCurrentHDWallet() const

--- a/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationRequestWidget.cpp
+++ b/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationRequestWidget.cpp
@@ -81,6 +81,12 @@ bs::network::otc::Offer OTCNegotiationRequestWidget::offer() const
 
    result.inputs = selectedUTXOs();
 
+   auto walletType = UiUtils::getSelectedWalletType(ui_->comboBoxXBTWallets);
+   if (walletType & UiUtils::WalletsTypes::HardwareSW) {
+      auto purpose = UiUtils::getHwWalletPurpose(walletType);
+      result.walletPurpose.reset(new bs::hd::Purpose(purpose));
+   }
+
    return result;
 }
 

--- a/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationRequestWidget.cpp
+++ b/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationRequestWidget.cpp
@@ -315,7 +315,13 @@ void OTCNegotiationRequestWidget::onMaxQuantityClicked()
 
    std::vector<UTXO> utxos = selectedUTXOs();
    if (utxos.empty()) {
-      utxos = getUtxoManager()->getAvailableXbtUTXOs(hdWallet->walletId());
+      if (hdWallet->isHardwareWallet()) {
+         auto purpose = UiUtils::getSelectedHwPurpose(ui_->comboBoxXBTWallets);
+         utxos = getUtxoManager()->getAvailableXbtUTXOs(hdWallet->walletId(), purpose);
+      }
+      else {
+         utxos = getUtxoManager()->getAvailableXbtUTXOs(hdWallet->walletId());
+      }
    }
 
    auto feeCb = [this, parentWidget = QPointer<OTCWindowsAdapterBase>(this), utxos = std::move(utxos)](float fee) {

--- a/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationResponseWidget.cpp
+++ b/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationResponseWidget.cpp
@@ -220,23 +220,13 @@ void OTCNegotiationResponseWidget::onAcceptOrUpdateClicked()
       return;
    }
 
-   const auto hdWallet = getCurrentHDWalletFromCombobox(ui_->comboBoxXBTWallets);
-   if (!hdWallet) {
-      return;
-   }
-
-   auto cbUtxoSet = [wdgt = QPointer<OTCNegotiationResponseWidget>(this), signal](std::vector<UTXO>&& utxos) {
-      if (!wdgt) {
-         return;
-      }
-
-      wdgt->setSelectedInputs(utxos);
-      wdgt->setReservation(wdgt->getUtxoManager()->makeNewReservation(utxos));
-      signal.invoke(wdgt);
-   };
-
-   getUtxoManager()->getBestXbtUtxoSet(hdWallet->walletId(), bs::XBTAmount(ui_->quantitySpinBox->value()).GetValue()
-      , std::move(cbUtxoSet), true);
+   submitProposal(ui_->comboBoxXBTWallets, bs::XBTAmount(ui_->quantitySpinBox->value()),
+      [caller = QPointer<OTCNegotiationResponseWidget>(this), signal]() {
+         if (!caller) {
+            return;
+         }
+         signal.invoke(caller);
+   });
 }
 
 void OTCNegotiationResponseWidget::onShowXBTInputsClicked()

--- a/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationResponseWidget.cpp
+++ b/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationResponseWidget.cpp
@@ -111,6 +111,12 @@ bs::network::otc::Offer OTCNegotiationResponseWidget::offer() const
 
    result.inputs = selectedUTXOs();
 
+   auto walletType = UiUtils::getSelectedWalletType(ui_->comboBoxXBTWallets);
+   if (walletType & UiUtils::WalletsTypes::HardwareSW) {
+      auto purpose = UiUtils::getHwWalletPurpose(walletType);
+      result.walletPurpose.reset(new bs::hd::Purpose(purpose));
+   }
+
    return result;
 }
 

--- a/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCWindowsAdapterBase.cpp
+++ b/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCWindowsAdapterBase.cpp
@@ -130,9 +130,7 @@ void OTCWindowsAdapterBase::showXBTInputs(QComboBox *walletsCombobox)
 
    std::vector<UTXO> allUTXOs;
    if (hdWallet->isHardwareWallet()) {
-      const auto walletType = static_cast<UiUtils::WalletsTypes>(
-         walletsCombobox->currentData(UiUtils::WalletType).toInt());
-      auto purpose = UiUtils::getHwWalletPurpose(walletType);
+      auto purpose = UiUtils::getSelectedHwPurpose(walletsCombobox);
       allUTXOs = getUtxoManager()->getAvailableXbtUTXOs(hdWallet->walletId(), purpose);
    }
    else {
@@ -219,9 +217,7 @@ BTCNumericTypes::balance_type OTCWindowsAdapterBase::getXBTSpendableBalanceFromC
    if (selectedUTXO_.empty()) {
       BTCNumericTypes::satoshi_type sum = 0;
       if (hdWallet->isHardwareWallet()) {
-         const auto walletType = static_cast<UiUtils::WalletsTypes>(
-            walletsCombobox->currentData(UiUtils::WalletType).toInt());
-         auto purpose = UiUtils::getHwWalletPurpose(walletType);
+         auto purpose = UiUtils::getSelectedHwPurpose(walletsCombobox);
          sum = getUtxoManager()->getAvailableXbtUtxoSum(hdWallet->walletId(), purpose);
       }
       else {
@@ -264,9 +260,7 @@ void OTCWindowsAdapterBase::submitProposal(QComboBox *walletsCombobox, bs::XBTAm
    };
 
    if (hdWallet->isHardwareWallet()) {
-      const auto walletType = static_cast<UiUtils::WalletsTypes>(
-         walletsCombobox->currentData(UiUtils::WalletType).toInt());
-      auto purpose = UiUtils::getHwWalletPurpose(walletType);
+      auto purpose = UiUtils::getSelectedHwPurpose(walletsCombobox);
       getUtxoManager()->getBestXbtUtxoSet(hdWallet->walletId(), purpose, amount.GetValue()
          , std::move(cbUtxoSet), true);
    }

--- a/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCWindowsAdapterBase.cpp
+++ b/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCWindowsAdapterBase.cpp
@@ -117,16 +117,28 @@ void OTCWindowsAdapterBase::onUpdateBalances()
 
 void OTCWindowsAdapterBase::showXBTInputsClicked(QComboBox *walletsCombobox)
 {
-   const auto &hdWallet = getCurrentHDWalletFromCombobox(walletsCombobox);
    reservation_.release();
-   showXBTInputs(hdWallet->walletId());
+   showXBTInputs(walletsCombobox);
 }
 
-void OTCWindowsAdapterBase::showXBTInputs(const std::string& walletId)
+void OTCWindowsAdapterBase::showXBTInputs(QComboBox *walletsCombobox)
 {
    const bool useAutoSel = selectedUTXO_.empty();
 
-   std::vector<UTXO> allUTXOs = getUtxoManager()->getAvailableXbtUTXOs(walletId);
+
+   const auto &hdWallet = getCurrentHDWalletFromCombobox(walletsCombobox);
+
+   std::vector<UTXO> allUTXOs;
+   if (hdWallet->isHardwareWallet()) {
+      const auto walletType = static_cast<UiUtils::WalletsTypes>(
+         walletsCombobox->currentData(UiUtils::WalletType).toInt());
+      auto purpose = UiUtils::getHwWalletPurpose(walletType);
+      allUTXOs = getUtxoManager()->getAvailableXbtUTXOs(hdWallet->walletId(), purpose);
+   }
+   else {
+      allUTXOs = getUtxoManager()->getAvailableXbtUTXOs(hdWallet->walletId());
+   }
+
    auto inputs = std::make_shared<SelectedTransactionInputs>(allUTXOs);
 
    // Set this to false is needed otherwise current selection would be cleared
@@ -149,7 +161,7 @@ void OTCWindowsAdapterBase::showXBTInputs(const std::string& walletId)
    if (bs::UtxoReservation::instance()->containsReservedUTXO(selectedInputs)) {
       BSMessageBox(BSMessageBox::critical, tr("UTXO reservation failed"),
          tr("Some of selected UTXOs has been already reserved"), this).exec();
-      showXBTInputs(walletId);
+      showXBTInputs(walletsCombobox);
       return;
    }
    selectedUTXO_ = std::move(selectedInputs);
@@ -205,7 +217,18 @@ BTCNumericTypes::balance_type OTCWindowsAdapterBase::getXBTSpendableBalanceFromC
 
    BTCNumericTypes::balance_type totalBalance{};
    if (selectedUTXO_.empty()) {
-      return bs::XBTAmount(getUtxoManager()->getAvailableXbtUtxoSum(hdWallet->walletId())).GetValueBitcoin();
+      BTCNumericTypes::satoshi_type sum = 0;
+      if (hdWallet->isHardwareWallet()) {
+         const auto walletType = static_cast<UiUtils::WalletsTypes>(
+            walletsCombobox->currentData(UiUtils::WalletType).toInt());
+         auto purpose = UiUtils::getHwWalletPurpose(walletType);
+         sum = getUtxoManager()->getAvailableXbtUtxoSum(hdWallet->walletId(), purpose);
+      }
+      else {
+         sum = getUtxoManager()->getAvailableXbtUtxoSum(hdWallet->walletId());
+      }
+
+      return bs::XBTAmount(sum).GetValueBitcoin();
    }
    else {
       for (const auto &utxo : selectedUTXO_) {
@@ -220,6 +243,37 @@ std::shared_ptr<bs::sync::hd::Wallet> OTCWindowsAdapterBase::getCurrentHDWalletF
 {
    const auto walletId = walletsCombobox->currentData(UiUtils::WalletIdRole).toString().toStdString();
    return getWalletManager()->getHDWalletById(walletId);
+}
+
+void OTCWindowsAdapterBase::submitProposal(QComboBox *walletsCombobox, bs::XBTAmount amount,  CbSuccess onSuccess)
+{
+   const auto hdWallet = getCurrentHDWalletFromCombobox(walletsCombobox);
+   if (!hdWallet) {
+      return;
+   }
+
+   auto cbUtxoSet = [caller = QPointer<OTCWindowsAdapterBase>(this), cbSuccess = std::move(onSuccess)](std::vector<UTXO>&& utxos) {
+      if (!caller) {
+         return;
+      }
+
+      caller->setSelectedInputs(utxos);
+      caller->setReservation(caller->getUtxoManager()->makeNewReservation(utxos));
+
+      cbSuccess();
+   };
+
+   if (hdWallet->isHardwareWallet()) {
+      const auto walletType = static_cast<UiUtils::WalletsTypes>(
+         walletsCombobox->currentData(UiUtils::WalletType).toInt());
+      auto purpose = UiUtils::getHwWalletPurpose(walletType);
+      getUtxoManager()->getBestXbtUtxoSet(hdWallet->walletId(), purpose, amount.GetValue()
+         , std::move(cbUtxoSet), true);
+   }
+   else {
+      getUtxoManager()->getBestXbtUtxoSet(hdWallet->walletId(), amount.GetValue()
+         , std::move(cbUtxoSet), true);
+   }
 }
 
 QString OTCWindowsAdapterBase::getXBTRange(bs::network::otc::Range xbtRange)

--- a/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCWindowsAdapterBase.h
+++ b/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCWindowsAdapterBase.h
@@ -52,6 +52,7 @@ struct TimeoutData
    QPointer<QLabel> labelTimeLeft_{};
 };
 
+using CbSuccess = std::function<void(void)>;
 class OTCWindowsAdapterBase : public QWidget {
    Q_OBJECT
 public:
@@ -97,6 +98,8 @@ protected:
    BTCNumericTypes::balance_type getXBTSpendableBalanceFromCombobox(QComboBox *walletsCombobox) const;
    std::shared_ptr<bs::sync::hd::Wallet> getCurrentHDWalletFromCombobox(QComboBox *walletsCombobox) const;
 
+   void submitProposal(QComboBox *walletsCombobox, bs::XBTAmount amount, CbSuccess onSuccess);
+
    QString getXBTRange(bs::network::otc::Range xbtRange);
    QString getCCRange(bs::network::otc::Range ccRange);
 
@@ -127,7 +130,7 @@ protected:
    bs::UtxoReservationToken reservation_;
 
 private:
-   void showXBTInputs(const std::string& walletId);
+   void showXBTInputs(QComboBox *walletsCombobox);
 
    QTimer timeoutTimer_;
    TimeoutData currentTimeoutData_{};

--- a/BlockSettleUILib/CreateTransactionDialog.cpp
+++ b/BlockSettleUILib/CreateTransactionDialog.cpp
@@ -298,12 +298,15 @@ void CreateTransactionDialog::selectedWalletChanged(int, bool resetInputs, const
    }
 
    auto group = rootWallet->getGroup(rootWallet->getXBTGroupType());
-   auto walletType = UiUtils::getSelectedWalletType(comboBoxWallets());
+   const bool isHardware = rootWallet->isHardwareWallet();
+   bs::hd::Purpose hwPurpose;
+   if (isHardware) {
+      hwPurpose = UiUtils::getSelectedHwPurpose(comboBoxWallets());
+   }
 
-   if (transactionData_->getGroup() != group || (walletType & UiUtils::HardwareAll) || resetInputs) {
-      if (walletType & UiUtils::HardwareAll) {
-         auto purpose = getHwWalletPurpose(walletType);
-         transactionData_->setWallet(group->getLeaf(purpose), armory_->topBlock()
+   if (transactionData_->getGroup() != group || rootWallet->isHardwareWallet() || resetInputs) {
+      if (rootWallet->isHardwareWallet()) {
+         transactionData_->setWallet(group->getLeaf(hwPurpose), armory_->topBlock()
             , resetInputs, cbInputsReset);
       }
       else {
@@ -311,6 +314,8 @@ void CreateTransactionDialog::selectedWalletChanged(int, bool resetInputs, const
             , resetInputs, cbInputsReset);
       }
    }
+
+   emit walletChanged();
 }
 
 void CreateTransactionDialog::onTransactionUpdated()

--- a/BlockSettleUILib/CreateTransactionDialog.cpp
+++ b/BlockSettleUILib/CreateTransactionDialog.cpp
@@ -205,7 +205,7 @@ int CreateTransactionDialog::SelectWallet(const std::string& walletId)
 
 void CreateTransactionDialog::populateWalletsList()
 {
-   int index = UiUtils::fillHDWalletsComboBox(comboBoxWallets(), walletsManager_, UiUtils::WalletsTypes::All_AllowLegacy);
+   int index = UiUtils::fillHDWalletsComboBox(comboBoxWallets(), walletsManager_, UiUtils::WalletsTypes::All_AllowHwLegacy);
    selectedWalletChanged(index);
 }
 
@@ -300,10 +300,10 @@ void CreateTransactionDialog::selectedWalletChanged(int, bool resetInputs, const
    auto group = rootWallet->getGroup(rootWallet->getXBTGroupType());
    auto walletType = UiUtils::getSelectedWalletType(comboBoxWallets());
 
-   if ((transactionData_->getGroup() != group || walletType == UiUtils::Hardware_Legacy) || resetInputs) {
-      if (walletType == UiUtils::Hardware_Legacy) {
-         auto wallet = group->getLeaf(bs::hd::Purpose::NonSegWit);
-         transactionData_->setWallet(wallet, armory_->topBlock()
+   if (transactionData_->getGroup() != group || (walletType & UiUtils::HardwareAll) || resetInputs) {
+      if (walletType & UiUtils::HardwareAll) {
+         auto purpose = getHwWalletPurpose(walletType);
+         transactionData_->setWallet(group->getLeaf(purpose), armory_->topBlock()
             , resetInputs, cbInputsReset);
       }
       else {

--- a/BlockSettleUILib/CreateTransactionDialog.h
+++ b/BlockSettleUILib/CreateTransactionDialog.h
@@ -108,6 +108,7 @@ protected:
 
 signals:
    void feeLoadingCompleted(const std::map<unsigned int, float> &);
+   void walletChanged();
 
 protected slots:
    virtual void onFeeSuggestionsLoaded(const std::map<unsigned int, float> &);

--- a/BlockSettleUILib/CreateTransactionDialogAdvanced.cpp
+++ b/BlockSettleUILib/CreateTransactionDialogAdvanced.cpp
@@ -400,6 +400,49 @@ void CreateTransactionDialogAdvanced::setRBFinputs(const Tx &tx)
    armory_->getTXsByHash(txHashSet, cbTXs, true);
 }
 
+void CreateTransactionDialogAdvanced::onUpdateChangeWidget()
+{
+   auto walletType = UiUtils::getSelectedWalletType(comboBoxWallets());
+
+   ui_->radioButtonExistingAddress->setVisible(false);
+   ui_->radioButtonNewAddrNative->setVisible(false);
+   ui_->radioButtonNewAddrNested->setVisible(false);
+   ui_->radioButtonNewAddrLegacy->setVisible(false);
+
+   switch (walletType)
+   {
+   case UiUtils::WalletsTypes::Full:
+   case UiUtils::WalletsTypes::WatchOnly:
+   {
+      ui_->radioButtonExistingAddress->setVisible(true);
+      ui_->radioButtonNewAddrNative->setVisible(true);
+      ui_->radioButtonNewAddrNested->setVisible(true);
+      ui_->radioButtonNewAddrNative->setChecked(true);
+   }
+   break;
+   case UiUtils::WalletsTypes::HardwareLegacy:
+      ui_->radioButtonNewAddrLegacy->setVisible(true);
+      ui_->radioButtonNewAddrLegacy->setChecked(true);
+      break;
+   case UiUtils::WalletsTypes::HardwareNativeSW:
+   {
+      ui_->radioButtonNewAddrNative->setVisible(true);
+      ui_->radioButtonNewAddrNative->setChecked(true);
+      break;
+   }  
+   case UiUtils::WalletsTypes::HardwareNestedSW:
+   {
+      ui_->radioButtonNewAddrNested->setVisible(true);
+      ui_->radioButtonNewAddrNested->setChecked(true);
+      break;
+   }
+   default:
+      break;
+   }
+
+   ui_->widgetChangeAddress->setEnabled(!(walletType & UiUtils::WalletsTypes::HardwareAll));
+}
+
 void CreateTransactionDialogAdvanced::initUI()
 {
    usedInputsModel_ = new UsedInputsModel(this);
@@ -465,6 +508,9 @@ void CreateTransactionDialogAdvanced::initUI()
       , this, &CreateTransactionDialogAdvanced::setTxFees);
    connect(ui_->spinBoxFeesManualTotal, QOverload<int>::of(&QSpinBox::valueChanged)
       , this, &CreateTransactionDialogAdvanced::setTxFees);
+
+   // Signal from parent class
+   connect(this, &CreateTransactionDialogAdvanced::walletChanged, this, &CreateTransactionDialogAdvanced::onUpdateChangeWidget);
 
    updateManualFeeControls();
 }
@@ -1063,7 +1109,8 @@ void CreateTransactionDialogAdvanced::getChangeAddress(AddressCb cb) const
          cb(selectedChangeAddress_);
          return;
       }
-      else if (ui_->radioButtonNewAddrNative->isChecked() || ui_->radioButtonNewAddrNested->isChecked()) {
+      else if (ui_->radioButtonNewAddrNative->isChecked() || ui_->radioButtonNewAddrNested->isChecked()
+         || ui_->radioButtonNewAddrLegacy->isChecked()) {
          const auto group = transactionData_->getGroup();
          std::shared_ptr<bs::sync::Wallet> wallet;
          if (group) {

--- a/BlockSettleUILib/CreateTransactionDialogAdvanced.h
+++ b/BlockSettleUILib/CreateTransactionDialogAdvanced.h
@@ -129,6 +129,7 @@ private slots:
    void setTxFees();
    void onOutputsClicked(const QModelIndex &index);
    void onSimpleDialogRequested();
+   void onUpdateChangeWidget();
 
 private:
    void clear() override;

--- a/BlockSettleUILib/CreateTransactionDialogAdvanced.ui
+++ b/BlockSettleUILib/CreateTransactionDialogAdvanced.ui
@@ -1292,6 +1292,13 @@
              </widget>
             </item>
             <item>
+             <widget class="QRadioButton" name="radioButtonNewAddrLegacy">
+              <property name="text">
+               <string>Legacy</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QRadioButton" name="radioButtonExistingAddress">
               <property name="text">
                <string>Select Existing</string>

--- a/BlockSettleUILib/Trading/DealerCCSettlementContainer.cpp
+++ b/BlockSettleUILib/Trading/DealerCCSettlementContainer.cpp
@@ -35,8 +35,9 @@ DealerCCSettlementContainer::DealerCCSettlementContainer(const std::shared_ptr<s
    , const std::shared_ptr<SignContainer> &container
    , const std::shared_ptr<ArmoryConnection> &armory
    , const std::shared_ptr<bs::sync::WalletsManager> &walletsMgr
+   , std::unique_ptr<bs::hd::Purpose> walletPurpose
    , bs::UtxoReservationToken utxoRes)
-   : bs::SettlementContainer(std::move(utxoRes))
+   : bs::SettlementContainer(std::move(utxoRes), std::move(walletPurpose))
    , logger_(logger)
    , order_(order)
    , lotSize_(lotSize)

--- a/BlockSettleUILib/Trading/DealerCCSettlementContainer.h
+++ b/BlockSettleUILib/Trading/DealerCCSettlementContainer.h
@@ -46,6 +46,7 @@ public:
       , const std::shared_ptr<SignContainer> &
       , const std::shared_ptr<ArmoryConnection> &
       , const std::shared_ptr<bs::sync::WalletsManager> &walletsMgr
+      , std::unique_ptr<bs::hd::Purpose> walletPurpose
       , bs::UtxoReservationToken utxoRes);
    ~DealerCCSettlementContainer() override;
 

--- a/BlockSettleUILib/Trading/DealerXBTSettlementContainer.h
+++ b/BlockSettleUILib/Trading/DealerXBTSettlementContainer.h
@@ -57,6 +57,7 @@ public:
       , const std::vector<UTXO> &utxosPayinFixed
       , const bs::Address &recvAddr
       , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
+      , std::unique_ptr<bs::hd::Purpose> walletPurpose
       , bs::UtxoReservationToken utxoRes);
    ~DealerXBTSettlementContainer() override;
 

--- a/BlockSettleUILib/Trading/OtcClient.cpp
+++ b/BlockSettleUILib/Trading/OtcClient.cpp
@@ -1458,8 +1458,16 @@ void OtcClient::createSellerRequest(const std::string &settlementId, Peer *peer,
       return;
    }
 
-   auto leaves = targetHdWallet->getGroup(targetHdWallet->getXBTGroupType())->getLeaves();
-   auto xbtWallets = std::vector<std::shared_ptr<bs::sync::Wallet>>(leaves.begin(), leaves.end());
+   auto group = targetHdWallet->getGroup(targetHdWallet->getXBTGroupType());
+   std::vector<std::shared_ptr<bs::sync::Wallet>> xbtWallets;
+   if (targetHdWallet->isHardwareWallet()) {
+      assert(peer->offer.walletPurpose);
+      xbtWallets.push_back(group->getLeaf(*peer->offer.walletPurpose));
+   }
+   else {
+      xbtWallets = group->getAllLeaves();
+   }
+
    if (xbtWallets.empty()) {
       cb(OtcClientDeal::error("can't find XBT wallets"));
       return;

--- a/BlockSettleUILib/Trading/RFQDealerReply.cpp
+++ b/BlockSettleUILib/Trading/RFQDealerReply.cpp
@@ -386,7 +386,7 @@ void RFQDealerReply::updateUiWalletFor(const bs::network::QuoteReqNotification &
 
       updateWalletsList((qrn.side == bs::network::Side::Sell) ? UiUtils::WalletsTypes::Full : UiUtils::WalletsTypes::All);
    } else if (qrn.assetType == bs::network::Asset::SpotXBT) {
-      updateWalletsList((qrn.side == bs::network::Side::Sell) ? (UiUtils::WalletsTypes::Full | UiUtils::WalletsTypes::Hardware) : UiUtils::WalletsTypes::All);
+      updateWalletsList((qrn.side == bs::network::Side::Sell) ? (UiUtils::WalletsTypes::Full | UiUtils::WalletsTypes::HardwareSW) : UiUtils::WalletsTypes::All);
    }
 }
 

--- a/BlockSettleUILib/Trading/RFQDealerReply.cpp
+++ b/BlockSettleUILib/Trading/RFQDealerReply.cpp
@@ -643,6 +643,11 @@ void RFQDealerReply::submitReply(const bs::network::QuoteReqNotification &qrn, d
          SPDLOG_LOGGER_ERROR(logger_, "can't submit CC/XBT reply without XBT wallet");
          return;
       }
+
+      if (replyData->xbtWallet->isHardwareWallet()) {
+         auto purpose = UiUtils::getSelectedHwPurpose(ui_->comboBoxXbtWallet);
+         replyData->walletPurpose.reset(new bs::hd::Purpose(purpose));
+      }
    }
 
    if (qrn.assetType == bs::network::Asset::SpotXBT) {

--- a/BlockSettleUILib/Trading/RFQDealerReply.h
+++ b/BlockSettleUILib/Trading/RFQDealerReply.h
@@ -24,6 +24,7 @@
 #include "CommonTypes.h"
 #include "EncryptionUtils.h"
 #include "QWalletInfo.h"
+#include "HDPath.h"
 #include "UtxoReservationToken.h"
 
 namespace Ui {
@@ -77,6 +78,7 @@ namespace bs {
          std::shared_ptr<bs::sync::hd::Wallet> xbtWallet;
          bs::Address authAddr;
          std::vector<UTXO> fixedXbtInputs;
+         std::unique_ptr<bs::hd::Purpose> walletPurpose;
       };
 
       class RFQDealerReply : public QWidget

--- a/BlockSettleUILib/Trading/RFQDialog.cpp
+++ b/BlockSettleUILib/Trading/RFQDialog.cpp
@@ -23,6 +23,7 @@
 #include "UiUtils.h"
 #include "UtxoReservationManager.h"
 #include "WalletSignerContainer.h"
+#include "Wallets/SyncHDWallet.h"
 
 
 RFQDialog::RFQDialog(const std::shared_ptr<spdlog::logger> &logger
@@ -97,6 +98,11 @@ RFQDialog::RFQDialog(const std::shared_ptr<spdlog::logger> &logger
 }
 
 RFQDialog::~RFQDialog() = default;
+
+void RFQDialog::setHwWalletPurpose(bs::hd::Purpose purpose)
+{
+   hwPurpose_ = purpose;
+}
 
 void RFQDialog::onOrderFilled(const std::string &quoteId)
 {
@@ -215,6 +221,10 @@ std::shared_ptr<bs::SettlementContainer> RFQDialog::newCCcontainer()
    try {
       ccSettlContainer_ = std::make_shared<ReqCCSettlementContainer>(logger_
          , signContainer_, armory_, assetMgr_, walletsManager_, rfq_, quote_, xbtWallet_, fixedXbtInputs_, utxoReservationManager_, std::move(ccUtxoRes_));
+
+      if (xbtWallet_->isHardwareWallet()) {
+         ccSettlContainer_->setHwWalletPurpose(hwPurpose_);
+      }
 
       connect(ccSettlContainer_.get(), &ReqCCSettlementContainer::txSigned
          , this, &RFQDialog::onCCTxSigned);

--- a/BlockSettleUILib/Trading/RFQDialog.h
+++ b/BlockSettleUILib/Trading/RFQDialog.h
@@ -76,11 +76,10 @@ public:
       , const std::map<UTXO, std::string> &fixedXbtInputs
       , bs::UtxoReservationToken fixedXbtUtxoRes
       , bs::UtxoReservationToken ccUtxoRes
+      , std::unique_ptr<bs::hd::Purpose> purpose
       , RFQRequestWidget* parent = nullptr);
    ~RFQDialog() override;
 
-   // Optional hw wallet purpose to detect correct wallet
-   void setHwWalletPurpose(bs::hd::Purpose purpose);
 protected:
    void reject() override;
 
@@ -145,7 +144,7 @@ private:
 
    QString           ccOrderId_;
    bs::UtxoReservationToken ccUtxoRes_;
-   bs::hd::Purpose hwPurpose_;
+   std::unique_ptr<bs::hd::Purpose> walletPurpose_;
 
 };
 

--- a/BlockSettleUILib/Trading/RFQDialog.h
+++ b/BlockSettleUILib/Trading/RFQDialog.h
@@ -18,6 +18,7 @@
 #include "CommonTypes.h"
 #include "UtxoReservationToken.h"
 #include "BSErrorCode.h"
+#include "HDPath.h"
 
 namespace Ui {
    class RFQDialog;
@@ -78,6 +79,8 @@ public:
       , RFQRequestWidget* parent = nullptr);
    ~RFQDialog() override;
 
+   // Optional hw wallet purpose to detect correct wallet
+   void setHwWalletPurpose(bs::hd::Purpose purpose);
 protected:
    void reject() override;
 
@@ -142,6 +145,7 @@ private:
 
    QString           ccOrderId_;
    bs::UtxoReservationToken ccUtxoRes_;
+   bs::hd::Purpose hwPurpose_;
 
 };
 

--- a/BlockSettleUILib/Trading/RFQReplyWidget.cpp
+++ b/BlockSettleUILib/Trading/RFQReplyWidget.cpp
@@ -233,6 +233,7 @@ void RFQReplyWidget::onReplied(const std::shared_ptr<bs::ui::SubmitQuoteReplyDat
          reply.authAddr = data->authAddr;
          reply.utxosPayinFixed = data->fixedXbtInputs;
          reply.utxoRes = std::move(data->utxoRes);
+         reply.walletPurpose = std::move(data->walletPurpose);
          break;
       }
 
@@ -243,6 +244,7 @@ void RFQReplyWidget::onReplied(const std::shared_ptr<bs::ui::SubmitQuoteReplyDat
          reply.requestorAuthAddress = data->qn.reqAuthKey;
          reply.utxoRes = std::move(data->utxoRes);
          reply.xbtWallet = data->xbtWallet;
+         reply.walletPurpose = std::move(data->walletPurpose);
          break;
       }
 
@@ -298,7 +300,7 @@ void RFQReplyWidget::onOrder(const bs::network::Order &order)
          try {
             const auto settlContainer = std::make_shared<DealerCCSettlementContainer>(logger_, order, quoteReqId
                , assetManager_->getCCLotSize(order.product), assetManager_->getCCGenesisAddr(order.product)
-               , sr.recipientAddress, sr.xbtWallet, signingContainer_, armory_, walletsManager_, std::move(sr.utxoRes));
+               , sr.recipientAddress, sr.xbtWallet, signingContainer_, armory_, walletsManager_, std::move(sr.walletPurpose), std::move(sr.utxoRes));
             connect(settlContainer.get(), &DealerCCSettlementContainer::signTxRequest, this, &RFQReplyWidget::saveTxData);
             connect(settlContainer.get(), &DealerCCSettlementContainer::error, this, &RFQReplyWidget::onTransactionError);
             connect(settlContainer.get(), &DealerCCSettlementContainer::cancelTrade, this, &RFQReplyWidget::cancelCCTrade);
@@ -333,7 +335,8 @@ void RFQReplyWidget::onOrder(const bs::network::Order &order)
             const auto recvXbtAddr = bs::Address();
             const auto settlContainer = std::make_shared<DealerXBTSettlementContainer>(logger_, order
                , walletsManager_, reply.xbtWallet, quoteProvider_, signingContainer_, armory_, authAddressManager_
-               , reply.authAddr, reply.utxosPayinFixed, recvXbtAddr, utxoReservationManager_, std::move(reply.utxoRes));
+               , reply.authAddr, reply.utxosPayinFixed, recvXbtAddr, utxoReservationManager_,
+               std::move(reply.walletPurpose), std::move(reply.utxoRes));
 
             connect(settlContainer.get(), &DealerXBTSettlementContainer::sendUnsignedPayinToPB, this, &RFQReplyWidget::sendUnsignedPayinToPB);
             connect(settlContainer.get(), &DealerXBTSettlementContainer::sendSignedPayinToPB, this, &RFQReplyWidget::sendSignedPayinToPB);

--- a/BlockSettleUILib/Trading/RFQReplyWidget.h
+++ b/BlockSettleUILib/Trading/RFQReplyWidget.h
@@ -23,6 +23,7 @@
 #include "CommonTypes.h"
 #include "TabWithShortcut.h"
 #include "UtxoReservationToken.h"
+#include "HDPath.h"
 
 namespace Ui {
     class RFQReplyWidget;
@@ -149,6 +150,7 @@ private:
       bs::Address authAddr;
       std::vector<UTXO> utxosPayinFixed;
       bs::UtxoReservationToken utxoRes;
+      std::unique_ptr<bs::hd::Purpose> walletPurpose;
    };
 
    struct SentCCReply
@@ -157,6 +159,7 @@ private:
       std::string                         requestorAuthAddress;
       std::shared_ptr<bs::sync::hd::Wallet>  xbtWallet;
       bs::UtxoReservationToken            utxoRes;
+      std::unique_ptr<bs::hd::Purpose> walletPurpose;
    };
 
 private:

--- a/BlockSettleUILib/Trading/RFQRequestWidget.cpp
+++ b/BlockSettleUILib/Trading/RFQRequestWidget.cpp
@@ -26,6 +26,7 @@
 #include "RfqStorage.h"
 #include "WalletSignerContainer.h"
 #include "Wallets/SyncWalletsManager.h"
+#include "Wallets/SyncHDWallet.h"
 #include "UtxoReservationManager.h"
 
 #include "bs_proxy_terminal_pb.pb.h"
@@ -281,6 +282,12 @@ void RFQRequestWidget::onRFQSubmit(const bs::network::RFQ& rfq, bs::UtxoReservat
    connect(this, &RFQRequestWidget::signedPayinRequested, dialog, &RFQDialog::onSignedPayinRequested);
 
    dialog->setAttribute(Qt::WA_DeleteOnClose);
+
+   if (xbtWallet->isHardwareWallet()) {
+      auto walletType = ui_->pageRFQTicket->xbtWalletType();
+      auto purpose = UiUtils::getHwWalletPurpose(walletType);
+      dialog->setHwWalletPurpose(purpose);
+   }
 
    dialogManager_->adjustDialogPosition(dialog);
    dialog->show();

--- a/BlockSettleUILib/Trading/RFQRequestWidget.cpp
+++ b/BlockSettleUILib/Trading/RFQRequestWidget.cpp
@@ -272,10 +272,16 @@ void RFQRequestWidget::onRFQSubmit(const bs::network::RFQ& rfq, bs::UtxoReservat
    auto xbtWallet = ui_->pageRFQTicket->xbtWallet();
    auto fixedXbtInputs = ui_->pageRFQTicket->fixedXbtInputs();
 
+   std::unique_ptr<bs::hd::Purpose> purpose;
+   if (xbtWallet->isHardwareWallet()) {
+      auto walletType = ui_->pageRFQTicket->xbtWalletType();
+      purpose.reset(new bs::hd::Purpose(UiUtils::getHwWalletPurpose(walletType)));
+   }
+
    RFQDialog* dialog = new RFQDialog(logger_, rfq, quoteProvider_
       , authAddressManager_, assetManager_, walletsManager_, signingContainer_, armory_, celerClient_, appSettings_
       , connectionManager_, rfqStorage_, xbtWallet, ui_->pageRFQTicket->recvXbtAddressIfSet(), authAddr, utxoReservationManager_
-      , fixedXbtInputs.inputs, std::move(fixedXbtInputs.utxoRes), std::move(ccUtxoRes), this);
+      , fixedXbtInputs.inputs, std::move(fixedXbtInputs.utxoRes), std::move(ccUtxoRes), std::move(purpose), this);
 
    connect(this, &RFQRequestWidget::unsignedPayinRequested, dialog, &RFQDialog::onUnsignedPayinRequested);
    connect(this, &RFQRequestWidget::signedPayoutRequested, dialog, &RFQDialog::onSignedPayoutRequested);
@@ -283,11 +289,7 @@ void RFQRequestWidget::onRFQSubmit(const bs::network::RFQ& rfq, bs::UtxoReservat
 
    dialog->setAttribute(Qt::WA_DeleteOnClose);
 
-   if (xbtWallet->isHardwareWallet()) {
-      auto walletType = ui_->pageRFQTicket->xbtWalletType();
-      auto purpose = UiUtils::getHwWalletPurpose(walletType);
-      dialog->setHwWalletPurpose(purpose);
-   }
+
 
    dialogManager_->adjustDialogPosition(dialog);
    dialog->show();

--- a/BlockSettleUILib/Trading/RFQTicketXBT.cpp
+++ b/BlockSettleUILib/Trading/RFQTicketXBT.cpp
@@ -303,7 +303,7 @@ void RFQTicketXBT::walletsLoaded()
       UiUtils::fillHDWalletsComboBox(ui_->comboBoxXBTWalletsRecv, walletsManager_, UiUtils::WalletsTypes::All);
       // CC does not support to send from Harware wallets
       int sendWalletTypes = (currentGroupType_ == ProductGroupType::CCGroupType) ?
-               UiUtils::WalletsTypes::Full : (UiUtils::WalletsTypes::Full | UiUtils::WalletsTypes::Hardware);
+               UiUtils::WalletsTypes::Full : (UiUtils::WalletsTypes::Full | UiUtils::WalletsTypes::HardwareSW);
       UiUtils::fillHDWalletsComboBox(ui_->comboBoxXBTWalletsSend, walletsManager_, sendWalletTypes);
    }
 

--- a/BlockSettleUILib/Trading/RFQTicketXBT.cpp
+++ b/BlockSettleUILib/Trading/RFQTicketXBT.cpp
@@ -919,6 +919,24 @@ std::shared_ptr<bs::sync::hd::Wallet> RFQTicketXBT::xbtWallet() const
    return nullptr;
 }
 
+UiUtils::WalletsTypes RFQTicketXBT::xbtWalletType() const
+{
+   QComboBox* combobox = nullptr;
+   if (getProductToSpend() == UiUtils::XbtCurrency) {
+      combobox = ui_->comboBoxXBTWalletsSend;
+   }
+   if (getProductToRecv() == UiUtils::XbtCurrency) {
+      combobox = ui_->comboBoxXBTWalletsRecv;
+   }
+
+   if (!combobox) {
+      return UiUtils::None;
+   }
+
+   return static_cast<UiUtils::WalletsTypes>(combobox->
+      currentData(UiUtils::WalletType).toInt());
+}
+
 void RFQTicketXBT::onParentAboutToHide()
 {
    fixedXbtInputs_ = {};

--- a/BlockSettleUILib/Trading/RFQTicketXBT.cpp
+++ b/BlockSettleUILib/Trading/RFQTicketXBT.cpp
@@ -338,7 +338,14 @@ void RFQTicketXBT::showCoinControl()
    // Need to release current reservation to be able select them back
    fixedXbtInputs_.utxoRes.release();
 
-   auto utxos = utxoReservationManager_->getAvailableXbtUTXOs(walletId);
+   std::vector<UTXO> utxos;
+   if (xbtWallet->isHardwareWallet()) {
+      auto purpose = UiUtils::getSelectedHwPurpose(ui_->comboBoxXBTWalletsSend);
+      utxos = utxoReservationManager_->getAvailableXbtUTXOs(xbtWallet->walletId(), purpose);
+   }
+   else {
+      utxos = utxoReservationManager_->getAvailableXbtUTXOs(xbtWallet->walletId());
+   }
 
    ui_->toolButtonXBTInputsSend->setEnabled(true);
    const bool useAutoSel = fixedXbtInputs_.inputs.empty();
@@ -988,7 +995,13 @@ void RFQTicketXBT::onMaxClicked()
             }
          }
          else {
-            utxos = utxoReservationManager_->getAvailableXbtUTXOs(xbtWallet->walletId());
+            if (xbtWallet->isHardwareWallet()) {
+               auto purpose = UiUtils::getSelectedHwPurpose(ui_->comboBoxXBTWalletsSend);
+               utxos = utxoReservationManager_->getAvailableXbtUTXOs(xbtWallet->walletId(), purpose);
+            }
+            else {
+               utxos = utxoReservationManager_->getAvailableXbtUTXOs(xbtWallet->walletId());
+            }
          }
 
          auto feeCb = [this, utxos = std::move(utxos)](float fee) {
@@ -1190,11 +1203,20 @@ bs::XBTAmount RFQTicketXBT::getXbtBalance() const
       return bs::XBTAmount(sum);
    }
 
-   if (!getSendXbtWallet()) {
+   auto xbtWallet = getSendXbtWallet();
+   if (!xbtWallet) {
       return bs::XBTAmount(0.0);
    }
 
-   return bs::XBTAmount(utxoReservationManager_->getAvailableXbtUtxoSum(getSendXbtWallet()->walletId()));
+   if (xbtWallet->isHardwareWallet()) {
+      auto purpose = UiUtils::getSelectedHwPurpose(ui_->comboBoxXBTWalletsSend);
+      return bs::XBTAmount(utxoReservationManager_->getAvailableXbtUtxoSum(
+         xbtWallet->walletId(), purpose));
+   }
+   else {
+      return bs::XBTAmount(utxoReservationManager_->getAvailableXbtUtxoSum(
+         xbtWallet->walletId()));
+   }
 }
 
 QString RFQTicketXBT::getProductToSpend() const
@@ -1228,20 +1250,33 @@ void RFQTicketXBT::reserveBestUtxoSetAndSubmit(const std::shared_ptr<bs::network
       }
       rfqTicket->submitRFQCb_(*rfq, std::move(rfqTicket->fixedXbtInputs_.utxoRes));
    };
-   auto cbBestUtxoSet = [rfqTicket = QPointer<RFQTicketXBT>(this), submitRFQWrapper] (bs::FixedXbtInputs&& fixedXbt) {
-      if (!rfqTicket) {
-         return;
+   auto getWalletAndReserve = [rfqTicket = QPointer<RFQTicketXBT>(this), submitRFQWrapper](BTCNumericTypes::satoshi_type amount, bool partial) {
+      auto cbBestUtxoSet = [rfqTicket, submitRFQWrapper](bs::FixedXbtInputs&& fixedXbt) {
+         if (!rfqTicket) {
+            return;
+         }
+         rfqTicket->fixedXbtInputs_ = std::move(fixedXbt);
+         submitRFQWrapper();
+      };
+
+      auto hdWallet = rfqTicket->getSendXbtWallet();
+      if (hdWallet->isHardwareWallet()) {
+         auto purpose = UiUtils::getSelectedHwPurpose(rfqTicket->ui_->comboBoxXBTWalletsSend);
+         rfqTicket->utxoReservationManager_->reserveBestXbtUtxoSet(
+            hdWallet->walletId(), purpose, amount,
+            partial, std::move(cbBestUtxoSet), true);
       }
-      rfqTicket->fixedXbtInputs_ = std::move(fixedXbt);
-      submitRFQWrapper();
+      else {
+         rfqTicket->utxoReservationManager_->reserveBestXbtUtxoSet(
+            hdWallet->walletId(), amount,
+            partial, std::move(cbBestUtxoSet), true);
+      }
    };
 
    if (rfq->assetType == bs::network::Asset::PrivateMarket
        && rfq->side == bs::network::Side::Buy) {
       auto maxXbtQuantity = getXbtReservationAmountForCc(rfq->quantity, getOfferPrice()).GetValue();
-      utxoReservationManager_->reserveBestXbtUtxoSet(
-         getSendXbtWallet()->walletId(), maxXbtQuantity,
-         true, std::move(cbBestUtxoSet), true);
+      getWalletAndReserve(maxXbtQuantity, true);
       return;
    }
 
@@ -1267,9 +1302,7 @@ void RFQTicketXBT::reserveBestUtxoSetAndSubmit(const std::shared_ptr<bs::network
    }
 
    const bool partial = rfq->assetType == bs::network::Asset::PrivateMarket;
-   utxoReservationManager_->reserveBestXbtUtxoSet(
-      getSendXbtWallet()->walletId(), quantity,
-      partial, std::move(cbBestUtxoSet), true);
+   getWalletAndReserve(quantity, partial);
 }
 
 void RFQTicketXBT::onCreateWalletClicked()

--- a/BlockSettleUILib/Trading/RFQTicketXBT.cpp
+++ b/BlockSettleUILib/Trading/RFQTicketXBT.cpp
@@ -933,8 +933,7 @@ UiUtils::WalletsTypes RFQTicketXBT::xbtWalletType() const
       return UiUtils::None;
    }
 
-   return static_cast<UiUtils::WalletsTypes>(combobox->
-      currentData(UiUtils::WalletType).toInt());
+   return UiUtils::getSelectedWalletType(combobox);
 }
 
 void RFQTicketXBT::onParentAboutToHide()

--- a/BlockSettleUILib/Trading/RFQTicketXBT.h
+++ b/BlockSettleUILib/Trading/RFQTicketXBT.h
@@ -23,6 +23,7 @@
 #include "CommonTypes.h"
 #include "UtxoReservationToken.h"
 #include "XBTAmount.h"
+#include "UiUtils.h"
 
 QT_BEGIN_NAMESPACE
 class QPushButton;
@@ -93,6 +94,7 @@ public:
    void setSubmitRFQ(SubmitRFQCb submitRFQCb);
 
    std::shared_ptr<bs::sync::hd::Wallet> xbtWallet() const;
+   UiUtils::WalletsTypes xbtWalletType() const;
 
    void onParentAboutToHide();
 

--- a/BlockSettleUILib/Trading/ReqCCSettlementContainer.cpp
+++ b/BlockSettleUILib/Trading/ReqCCSettlementContainer.cpp
@@ -34,8 +34,9 @@ ReqCCSettlementContainer::ReqCCSettlementContainer(const std::shared_ptr<spdlog:
    , const std::shared_ptr<bs::sync::hd::Wallet> &xbtWallet
    , const std::map<UTXO, std::string> &manualXbtInputs
    , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
+   , std::unique_ptr<bs::hd::Purpose> walletPurpose
    , bs::UtxoReservationToken utxoRes)
-   : bs::SettlementContainer(std::move(utxoRes))
+   : bs::SettlementContainer(std::move(utxoRes), std::move(walletPurpose))
    , logger_(logger)
    , signingContainer_(container)
    , xbtWallet_(xbtWallet)
@@ -268,7 +269,8 @@ bool ReqCCSettlementContainer::createCCUnsignedTXdata()
          if (manualXbtInputs_.empty()) {
             std::vector<UTXO> utxos;
             if (xbtWallet_->isHardwareWallet()) {
-               utxos = utxoReservationManager_->getAvailableXbtUTXOs(xbtWallet_->walletId(), hwWalletPurpose_);
+               assert(walletPurpose_);
+               utxos = utxoReservationManager_->getAvailableXbtUTXOs(xbtWallet_->walletId(), *walletPurpose_);
             }
             else {
                utxos = utxoReservationManager_->getAvailableXbtUTXOs(xbtWallet_->walletId());
@@ -395,9 +397,4 @@ std::string ReqCCSettlementContainer::txData() const
 void ReqCCSettlementContainer::setClOrdId(const std::string& clientOrderId)
 {
    clOrdId_ = clientOrderId;
-}
-
-void ReqCCSettlementContainer::setHwWalletPurpose(bs::hd::Purpose purpose)
-{
-   hwWalletPurpose_ = purpose;
 }

--- a/BlockSettleUILib/Trading/ReqCCSettlementContainer.cpp
+++ b/BlockSettleUILib/Trading/ReqCCSettlementContainer.cpp
@@ -266,7 +266,14 @@ bool ReqCCSettlementContainer::createCCUnsignedTXdata()
             xbtLeaves_.front()->getNewChangeAddress(changeAddrCb);
          };
          if (manualXbtInputs_.empty()) {
-            auto utxos = utxoReservationManager_->getAvailableXbtUTXOs(xbtWallet_->walletId());
+            std::vector<UTXO> utxos;
+            if (xbtWallet_->isHardwareWallet()) {
+               utxos = utxoReservationManager_->getAvailableXbtUTXOs(xbtWallet_->walletId(), hwWalletPurpose_);
+            }
+            else {
+               utxos = utxoReservationManager_->getAvailableXbtUTXOs(xbtWallet_->walletId());
+            }
+
             auto fixedUtxo = utxoReservationManager_->convertUtxoToPartialFixedInput(xbtWallet_->walletId(), utxos);
             inputsCb(fixedUtxo.inputs);
          } else {
@@ -388,4 +395,9 @@ std::string ReqCCSettlementContainer::txData() const
 void ReqCCSettlementContainer::setClOrdId(const std::string& clientOrderId)
 {
    clOrdId_ = clientOrderId;
+}
+
+void ReqCCSettlementContainer::setHwWalletPurpose(bs::hd::Purpose purpose)
+{
+   hwWalletPurpose_ = purpose;
 }

--- a/BlockSettleUILib/Trading/ReqCCSettlementContainer.h
+++ b/BlockSettleUILib/Trading/ReqCCSettlementContainer.h
@@ -47,6 +47,7 @@ public:
       , const std::shared_ptr<bs::sync::hd::Wallet> &xbtWallet
       , const std::map<UTXO, std::string> &manualXbtInputs
       , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
+      , std::unique_ptr<bs::hd::Purpose> walletPurpose
       , bs::UtxoReservationToken utxoRes);
    ~ReqCCSettlementContainer() override;
 
@@ -72,7 +73,6 @@ public:
    bool startSigning(QDateTime timestamp);
 
    void setClOrdId(const std::string& clientOrderId);
-   void setHwWalletPurpose(bs::hd::Purpose purpose);
 
 signals:
    void sendOrder();
@@ -126,7 +126,6 @@ private:
    std::map<UTXO, std::string> manualXbtInputs_;
 
    std::string clOrdId_;
-   bs::hd::Purpose hwWalletPurpose_;
 };
 
 #endif // __REQ_CC_SETTLEMENT_CONTAINER_H__

--- a/BlockSettleUILib/Trading/ReqCCSettlementContainer.h
+++ b/BlockSettleUILib/Trading/ReqCCSettlementContainer.h
@@ -72,6 +72,7 @@ public:
    bool startSigning(QDateTime timestamp);
 
    void setClOrdId(const std::string& clientOrderId);
+   void setHwWalletPurpose(bs::hd::Purpose purpose);
 
 signals:
    void sendOrder();
@@ -125,6 +126,7 @@ private:
    std::map<UTXO, std::string> manualXbtInputs_;
 
    std::string clOrdId_;
+   bs::hd::Purpose hwWalletPurpose_;
 };
 
 #endif // __REQ_CC_SETTLEMENT_CONTAINER_H__

--- a/BlockSettleUILib/Trading/ReqXBTSettlementContainer.h
+++ b/BlockSettleUILib/Trading/ReqXBTSettlementContainer.h
@@ -53,6 +53,7 @@ public:
       , const std::map<UTXO, std::string> &utxosPayinFixed
       , bs::UtxoReservationToken utxoRes
       , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
+      , std::unique_ptr<bs::hd::Purpose> walletPurpose
       , const bs::Address &recvAddrIfSet);
    ~ReqXBTSettlementContainer() override;
 

--- a/BlockSettleUILib/Trading/SettlementContainer.cpp
+++ b/BlockSettleUILib/Trading/SettlementContainer.cpp
@@ -20,9 +20,10 @@ namespace {
 
 } // namespace
 
-SettlementContainer::SettlementContainer(UtxoReservationToken utxoRes)
+SettlementContainer::SettlementContainer(UtxoReservationToken utxoRes, std::unique_ptr<bs::hd::Purpose> walletPurpose)
    : QObject(nullptr)
    , utxoRes_(std::move(utxoRes))
+   , walletPurpose_(std::move(walletPurpose))
 {}
 
 SettlementContainer::~SettlementContainer()

--- a/BlockSettleUILib/Trading/SettlementContainer.h
+++ b/BlockSettleUILib/Trading/SettlementContainer.h
@@ -31,7 +31,8 @@ namespace bs {
    {
       Q_OBJECT
    public:
-      explicit SettlementContainer(bs::UtxoReservationToken utxoRes);
+      explicit SettlementContainer(bs::UtxoReservationToken utxoRes,
+         std::unique_ptr<bs::hd::Purpose> walletPurpose);
       ~SettlementContainer() override;
 
       virtual bool cancel() = 0;
@@ -56,6 +57,7 @@ namespace bs {
          , QDateTime timestamp) const;
 
       static constexpr unsigned int kWaitTimeoutInSec = 30;
+
    signals:
       void error(bs::error::ErrorCode, QString);
 
@@ -75,13 +77,13 @@ namespace bs {
 
       ValidityFlag validityFlag_;
       bs::UtxoReservationToken utxoRes_;
+      std::unique_ptr<bs::hd::Purpose> walletPurpose_;
 
    private:
       QTimer   timer_;
       int      msDuration_ = 0;
       int      msTimeLeft_ = 0;
       std::chrono::steady_clock::time_point startTime_;
-
    };
 
 }  // namespace bs

--- a/BlockSettleUILib/UiUtils.cpp
+++ b/BlockSettleUILib/UiUtils.cpp
@@ -520,6 +520,13 @@ UiUtils::WalletsTypes UiUtils::getSelectedWalletType(QComboBox* comboBox)
    return static_cast<UiUtils::WalletsTypes>(comboBox->currentData(WalletType).toInt());
 }
 
+bs::hd::Purpose UiUtils::getSelectedHwPurpose(QComboBox* comboBox)
+{
+   const auto walletType = static_cast<UiUtils::WalletsTypes>(
+      comboBox->currentData(UiUtils::WalletType).toInt());
+   return UiUtils::getHwWalletPurpose(walletType);
+}
+
 static QtAwesome* qtAwesome_ = nullptr;
 
 void UiUtils::setupIconFont(QObject* parent)

--- a/BlockSettleUILib/UiUtils.h
+++ b/BlockSettleUILib/UiUtils.h
@@ -21,6 +21,7 @@
 #include "BTCNumericTypes.h"
 #include "ApplicationSettings.h"
 #include "CommonTypes.h"
+#include "HDPath.h"
 
 QT_BEGIN_NAMESPACE
 class QAbstractItemModel;
@@ -104,6 +105,8 @@ namespace UiUtils
    QString displayDateTime(const QDateTime& datetime);
    QString displayTimeMs(const QDateTime& datetime);
 
+   constexpr int bit(int b) { return 1 << b; }
+
    QString displayAddress(const QString &addr);
    QString displayShortAddress(const QString &addr, const uint maxLength);
    enum WalletDataRole
@@ -118,13 +121,17 @@ namespace UiUtils
 
    enum WalletsTypes : int
    {
-      Full = 0x1,
-      Hardware = 0x2,
-      Hardware_Legacy = 0x4,
-      WatchOnly = 0x8,
+      None = 0,
+      Full = bit(0),
+      WatchOnly = bit(1),
+      HardwareLegacy = bit(2),
+      HardwareNativeSW= bit(3),
+      HardwareNestedSW = bit(4),
 
-      All = Full | Hardware | WatchOnly,
-      All_AllowLegacy = Full | Hardware | Hardware_Legacy | WatchOnly
+      HardwareSW = HardwareNativeSW | HardwareNestedSW,
+      HardwareAll = HardwareSW | HardwareLegacy,
+      All = Full | HardwareSW | WatchOnly,
+      All_AllowHwLegacy = All | HardwareAll
    };
    int fillHDWalletsComboBox(QComboBox* comboBox, const std::shared_ptr<bs::sync::WalletsManager>& walletsManager
       , int walletTypes);
@@ -155,6 +162,8 @@ namespace UiUtils
    extern const QLatin1String XbtCurrency;
 
    double actualXbtPrice(bs::XBTAmount amount, double price);
+
+   bs::hd::Purpose getHwWalletPurpose(WalletsTypes hwType);
 
    //
    // WalletDescriptionValidator

--- a/BlockSettleUILib/UiUtils.h
+++ b/BlockSettleUILib/UiUtils.h
@@ -143,6 +143,7 @@ namespace UiUtils
    int selectWalletInCombobox(QComboBox* comboBox, const std::string& walletId);
    std::string getSelectedWalletId(QComboBox* comboBox);
    WalletsTypes getSelectedWalletType(QComboBox* comboBox);
+   bs::hd::Purpose getSelectedHwPurpose(QComboBox* comboBox);
 
    QPixmap getQRCode(const QString& address, int size = 0);
 

--- a/BlockSettleUILib/UtxoReservationManager.h
+++ b/BlockSettleUILib/UtxoReservationManager.h
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <QObject>
 #include "CommonTypes.h"
+#include "UiUtils.h"
 #include "UtxoReservationToken.h"
 
 namespace spdlog {
@@ -59,9 +60,14 @@ namespace bs {
       void reserveBestXbtUtxoSet(const HDWalletId& walletId, BTCNumericTypes::satoshi_type quantity, bool partial,
          std::function<void(FixedXbtInputs&&)>&& cb, bool checkPbFeeFloor);
       BTCNumericTypes::satoshi_type getAvailableXbtUtxoSum(const HDWalletId& walletId) const;
+      BTCNumericTypes::satoshi_type getAvailableXbtUtxoSum(const HDWalletId& walletId, bs::hd::Purpose purpose) const;
+      
       std::vector<UTXO> getAvailableXbtUTXOs(const HDWalletId& walletId) const;
+      std::vector<UTXO> getAvailableXbtUTXOs(const HDWalletId& walletId, bs::hd::Purpose purpose) const;
 
       void getBestXbtUtxoSet(const HDWalletId& walletId, BTCNumericTypes::satoshi_type quantity,
+         std::function<void(std::vector<UTXO>&&)>&& cb, bool checkPbFeeFloor);
+      void getBestXbtUtxoSet(const HDWalletId& walletId, bs::hd::Purpose purpose, BTCNumericTypes::satoshi_type quantity,
          std::function<void(std::vector<UTXO>&&)>&& cb, bool checkPbFeeFloor);
   
       // CC specific implementation
@@ -89,6 +95,8 @@ namespace bs {
       void resetSpendableXbt(const std::shared_ptr<bs::sync::hd::Wallet>& hdWallet);
       void resetSpendableCC(const std::shared_ptr<bs::sync::Wallet>& leaf);
       void resetAllSpendableCC(const std::shared_ptr<bs::sync::hd::Wallet>& hdWallet);
+      void getBestXbtFromUtxos(std::vector<UTXO> selectedUtxo, const HDWalletId& walletId, BTCNumericTypes::satoshi_type quantity,
+         std::function<void(std::vector<UTXO>&&)>&& cb, bool checkPbFeeFloor);
 
    private:
       struct XBTUtxoContainer {

--- a/BlockSettleUILib/UtxoReservationManager.h
+++ b/BlockSettleUILib/UtxoReservationManager.h
@@ -100,7 +100,7 @@ namespace bs {
       void resetSpendableXbt(const std::shared_ptr<bs::sync::hd::Wallet>& hdWallet);
       void resetSpendableCC(const std::shared_ptr<bs::sync::Wallet>& leaf);
       void resetAllSpendableCC(const std::shared_ptr<bs::sync::hd::Wallet>& hdWallet);
-      void getBestXbtFromUtxos(std::vector<UTXO> selectedUtxo, const HDWalletId& walletId, BTCNumericTypes::satoshi_type quantity,
+      void getBestXbtFromUtxos(std::vector<UTXO> selectedUtxo, BTCNumericTypes::satoshi_type quantity,
          std::function<void(std::vector<UTXO>&&)>&& cb, bool checkPbFeeFloor);
 
       std::function<void(std::vector<UTXO>&&)> getReservationCb(const HDWalletId& walletId, bool partial,

--- a/BlockSettleUILib/UtxoReservationManager.h
+++ b/BlockSettleUILib/UtxoReservationManager.h
@@ -56,9 +56,14 @@ namespace bs {
       UtxoReservationToken makeNewReservation(const std::vector<UTXO> &utxos, const std::string &reserveId);
       UtxoReservationToken makeNewReservation(const std::vector<UTXO> &utxos);
 
-      // Xbt specific implementation
+      // Xbt specific implementation, each function defined two times
+      // 1 - for hd wallet, and 2 - for hd leaf(wallet_id + purpose) which is needed for hw wallet
       void reserveBestXbtUtxoSet(const HDWalletId& walletId, BTCNumericTypes::satoshi_type quantity, bool partial,
          std::function<void(FixedXbtInputs&&)>&& cb, bool checkPbFeeFloor);
+      void reserveBestXbtUtxoSet(const HDWalletId& walletId, bs::hd::Purpose purpose,
+         BTCNumericTypes::satoshi_type quantity, bool partial,
+         std::function<void(FixedXbtInputs&&)>&& cb, bool checkPbFeeFloor);
+
       BTCNumericTypes::satoshi_type getAvailableXbtUtxoSum(const HDWalletId& walletId) const;
       BTCNumericTypes::satoshi_type getAvailableXbtUtxoSum(const HDWalletId& walletId, bs::hd::Purpose purpose) const;
       
@@ -97,6 +102,9 @@ namespace bs {
       void resetAllSpendableCC(const std::shared_ptr<bs::sync::hd::Wallet>& hdWallet);
       void getBestXbtFromUtxos(std::vector<UTXO> selectedUtxo, const HDWalletId& walletId, BTCNumericTypes::satoshi_type quantity,
          std::function<void(std::vector<UTXO>&&)>&& cb, bool checkPbFeeFloor);
+
+      std::function<void(std::vector<UTXO>&&)> getReservationCb(const HDWalletId& walletId, bool partial,
+         std::function<void(FixedXbtInputs&&)>&& cb);
 
    private:
       struct XBTUtxoContainer {


### PR DESCRIPTION
Issue: we need to have separate wallet per leaf when trading/making tx for hw wallet
In order to do that next steps were done in this review:
1. Fix combobox selection to have separate wallet per each leaf for hw wallet
2. Fix utxo reservation manager logic to work with separate leaf instead of hd wallet only.
3. Fix change address to be 1:1 from input wallet type(native-native, nested-nested, legacy-legacy)
4. Fix change widget in advanced create tx dialog.

Note : PM market trading is not done totally, it will be adjusted later when will be possible to make partial trading with HW wallet

depend on: https://github.com/BlockSettle/common/pull/1913