### PR TITLE
Fix legacy change for trezor

### DIFF
--- a/BlockSettleUILib/CreateTransactionDialogAdvanced.cpp
+++ b/BlockSettleUILib/CreateTransactionDialogAdvanced.cpp
@@ -1014,7 +1014,7 @@ void CreateTransactionDialogAdvanced::validateCreateButton()
    ui_->pushButtonCreate->setEnabled(isTxValid
       && !broadcasting_
       && (ui_->radioButtonNewAddrNative->isChecked() || ui_->radioButtonNewAddrNested->isChecked()
-         || (selectedChangeAddress_.isValid())));
+         || ui_->radioButtonNewAddrLegacy->isChecked() || (selectedChangeAddress_.isValid())));
 }
 
 void CreateTransactionDialogAdvanced::SetInputs(const std::vector<UTXO> &inputs)


### PR DESCRIPTION
Issues:
1. Button "Broadcast" is not available when selecting legacy input in "Advanced dialog"
2. Fix Trezor legacy change address type