### PR TITLE
Fix small ui issues and regressions

### DIFF
--- a/BlockSettleHW/hwcommonstructure.h
+++ b/BlockSettleHW/hwcommonstructure.h
@@ -84,6 +84,7 @@ bool isNonSegwit(const bs::hd::Path& path);
 namespace HWInfoStatus {
    const QString kPressButton = QObject::tr("Confirm transaction output(s) on your device");
    const QString kTransaction = QObject::tr("Loading transaction to your device....");
+   const QString kReceiveSignedTx = QObject::tr("Receiving signed transaction from device....");
    const QString kTransactionFinished = QObject::tr("Transaction signing finished with success");
    const QString kCancelledByUser = QObject::tr("Cancelled by user");
 }

--- a/BlockSettleHW/ledger/ledgerDevice.cpp
+++ b/BlockSettleHW/ledger/ledgerDevice.cpp
@@ -857,7 +857,7 @@ void LedgerCommandThread::processTXLegacy()
       // -- Done output section --
 
       // At this point user verified all outputs and we can start signing inputs
-      emit info(HWInfoStatus::kTransaction);
+      emit info(HWInfoStatus::kReceiveSignedTx);
 
       // -- Start signing one by one all addresses -- 
       logger_->debug("[LedgerCommandThread] processTXLegacy - Start signing section");
@@ -936,7 +936,7 @@ void LedgerCommandThread::processTXSegwit()
    // -- Done output section --
 
    // At this point user verified all outputs and we can start signing inputs
-   emit info(HWInfoStatus::kTransaction);
+   emit info(HWInfoStatus::kReceiveSignedTx);
 
    // -- Start signing one by one all addresses -- 
 

--- a/BlockSettleHW/trezor/trezorDevice.cpp
+++ b/BlockSettleHW/trezor/trezorDevice.cpp
@@ -323,6 +323,7 @@ void TrezorDevice::handleMessage(const MessageData& data)
          common::ButtonAck response;
          makeCall(response);
          sendTxMessage(HWInfoStatus::kPressButton);
+         txSignedByUser_ = true;
       }
       break;
    case MessageType_PinMatrixRequest:
@@ -362,7 +363,7 @@ void TrezorDevice::handleMessage(const MessageData& data)
    case MessageType_TxRequest:
       {
          handleTxRequest(data);
-         sendTxMessage(HWInfoStatus::kTransaction);
+         sendTxMessage(txSignedByUser_ ? HWInfoStatus::kReceiveSignedTx : HWInfoStatus::kTransaction);
       }
       break;
    default:

--- a/BlockSettleHW/trezor/trezorDevice.h
+++ b/BlockSettleHW/trezor/trezorDevice.h
@@ -104,6 +104,7 @@ private:
    HWSignedTx awaitingTransaction_;
    HwWalletWrapper awaitingWalletInfo_;
 
+   bool txSignedByUser_ = false;
    std::unordered_map<int, AsyncCallBack> awaitingCallbackNoData_;
    std::unordered_map<int, AsyncCallBackCall> awaitingCallbackData_;
    std::map<BinaryData, Tx> prevTxs_;

--- a/BlockSettleSigner/qml/BsDialogs/TxSignSettlementBaseDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/TxSignSettlementBaseDialog.qml
@@ -43,7 +43,6 @@ CustomTitleDialogWindowWithExpander {
     property string hwDeviceStatus: qsTr("Searching for device")
     onHeaderButtonClicked: {
         isExpanded = !isExpanded
-        signerSettings.defaultSettlDialogExpandedState = isExpanded
     }
 
     headerButtonText: isExpanded ? "Hide Details" : "Details"
@@ -142,10 +141,6 @@ CustomTitleDialogWindowWithExpander {
            return BSStyle.inputsValidColor;
        else
            return BSStyle.inputsInvalidColor;
-    }
-
-    Component.onCompleted: {
-        isExpanded = signerSettings.defaultSettlDialogExpandedState
     }
 
     Connections {

--- a/BlockSettleSigner/qml/BsDialogs/TxSignSettlementBaseDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/TxSignSettlementBaseDialog.qml
@@ -39,7 +39,7 @@ CustomTitleDialogWindowWithExpander {
     property bool signingIsNotSet: true
 
     // expanding
-    property bool isExpanded: false
+    property bool isExpanded: passwordDialogData.ExpandTxInfo
     property string hwDeviceStatus: qsTr("Searching for device")
     onHeaderButtonClicked: {
         isExpanded = !isExpanded

--- a/BlockSettleSigner/qml/js/helper.js
+++ b/BlockSettleSigner/qml/js/helper.js
@@ -890,7 +890,6 @@ function showDropHwDeviceMessage() {
     return JsHelper.messageBox(BSMessageBox.Type.Warning
         , qsTr("Hardware wallet transaction signing")
         , qsTr("Cancelling transaction on device")
-        , qsTr("The signer cannot force device to drop current transaction data due to device specification." +
-               " Please make sure you will reject data on device manually before next transaction on this device will be started." +
-               " Otherwise further transactions could lead to wrong result."));
+        , qsTr("The signer cannot force the device to drop the current transaction due to device specification. " +
+               "Please ensure that the transaction is manually rejected on your device before making further transactions"));
 }

--- a/BlockSettleUILib/AddressDetailDialog.cpp
+++ b/BlockSettleUILib/AddressDetailDialog.cpp
@@ -147,7 +147,7 @@ AddressDetailDialog::AddressDetailDialog(const bs::Address& address
    ui_->outputAddressesWidget->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
    if (armory_->state() != ArmoryState::Ready) {
-      ui_->labelError->setText(tr("Armory is not connected"));
+      ui_->labelError->setText(tr("BlockSettleDB is not connected"));
       onError();
    }
    else {

--- a/BlockSettleUILib/BSMessageBox.cpp
+++ b/BlockSettleUILib/BSMessageBox.cpp
@@ -200,6 +200,6 @@ MessageBoxBroadcastError::MessageBoxBroadcastError(const QString &details
 
 MessageBoxExpTimeout::MessageBoxExpTimeout(QWidget *parent)
    : BSMessageBox(BSMessageBox::warning, tr("Explorer Timeout"),
-      tr("Explorer Timeout"), tr("Armory has timed out. Cannot resolve query.")
+      tr("Explorer Timeout"), tr("BlockSettleDB has timed out. Cannot resolve query.")
       , parent)
 {}

--- a/BlockSettleUILib/BSTerminalMainWindow.cpp
+++ b/BlockSettleUILib/BSTerminalMainWindow.cpp
@@ -1260,7 +1260,7 @@ void BSTerminalMainWindow::onSend()
    }
 
    if (!selectedWalletId.empty()) {
-      dlg->SelectWallet(selectedWalletId);
+      dlg->SelectWallet(selectedWalletId, UiUtils::WalletsTypes::None);
    }
 
    while(true) {

--- a/BlockSettleUILib/BSTerminalMainWindow.cpp
+++ b/BlockSettleUILib/BSTerminalMainWindow.cpp
@@ -1743,10 +1743,10 @@ void BSTerminalMainWindow::onNodeStatus(NodeStatus nodeStatus, bool isSegWitEnab
    if (isBitcoinCoreOnline != isBitcoinCoreOnline_) {
       isBitcoinCoreOnline_ = isBitcoinCoreOnline;
       if (isBitcoinCoreOnline) {
-         SPDLOG_LOGGER_INFO(logMgr_->logger(), "ArmoryDB connected to Bitcoin Core RPC");
+         SPDLOG_LOGGER_INFO(logMgr_->logger(), "BlockSettleDB connected to Bitcoin Core RPC");
          NotificationCenter::notify(bs::ui::NotifyType::BitcoinCoreOnline, {});
       } else {
-         SPDLOG_LOGGER_ERROR(logMgr_->logger(), "ArmoryDB disconnected from Bitcoin Core RPC");
+         SPDLOG_LOGGER_ERROR(logMgr_->logger(), "BlockSettleDB disconnected from Bitcoin Core RPC");
          NotificationCenter::notify(bs::ui::NotifyType::BitcoinCoreOffline, {});
       }
    }
@@ -1901,7 +1901,7 @@ void BSTerminalMainWindow::showArmoryServerPrompt(const BinaryData &srvPubKey, c
       const auto &deferredDialog = [this, server, promiseObj, srvPubKey, srvIPPort]{
          if (server.armoryDBKey.isEmpty()) {
             ImportKeyBox box(BSMessageBox::question
-               , tr("Import ArmoryDB ID Key?")
+               , tr("Import BlockSettleDB ID Key?")
                , this);
 
             box.setNewKeyFromBinary(srvPubKey);
@@ -1917,7 +1917,7 @@ void BSTerminalMainWindow::showArmoryServerPrompt(const BinaryData &srvPubKey, c
          }
          else if (server.armoryDBKey.toStdString() != srvPubKey.toHexStr()) {
             ImportKeyBox box(BSMessageBox::question
-               , tr("Import ArmoryDB ID Key?")
+               , tr("Import BlockSettleDB ID Key?")
                , this);
 
             box.setNewKeyFromBinary(srvPubKey);

--- a/BlockSettleUILib/BSTerminalMainWindow.cpp
+++ b/BlockSettleUILib/BSTerminalMainWindow.cpp
@@ -159,8 +159,6 @@ BSTerminalMainWindow::BSTerminalMainWindow(const std::shared_ptr<ApplicationSett
 
    ui_->tabWidget->setCurrentIndex(settings->get<int>(ApplicationSettings::GUI_main_tab));
 
-   ui_->widgetTransactions->setAppSettings(applicationSettings_);
-
    UpdateMainWindowAppearence();
    setWidgetsAuthorized(false);
 
@@ -775,7 +773,8 @@ void BSTerminalMainWindow::tryInitChatView()
       const auto env = isProd ? bs::network::otc::Env::Prod : bs::network::otc::Env::Test;
 
       ui_->widgetChat->init(connectionManager_, env, chatClientServicePtr_,
-         logMgr_->logger("chat"), walletsMgr_, authManager_, armory_, signContainer_, mdCallbacks_, assetManager_, utxoReservationMgr_);
+         logMgr_->logger("chat"), walletsMgr_, authManager_, armory_, signContainer_,
+         mdCallbacks_, assetManager_, utxoReservationMgr_, applicationSettings_);
 
       connect(chatClientServicePtr_->getClientPartyModelPtr().get(), &Chat::ClientPartyModel::userPublicKeyChanged,
          this, [this](const Chat::UserPublicKeyInfoList& userPublicKeyInfoList) {
@@ -859,8 +858,8 @@ void BSTerminalMainWindow::InitChartsView()
 void BSTerminalMainWindow::InitTransactionsView()
 {
    ui_->widgetExplorer->init(armory_, logMgr_->logger(), walletsMgr_, ccFileManager_, authManager_);
-   ui_->widgetTransactions->init(walletsMgr_, armory_, utxoReservationMgr_, signContainer_,
-                                logMgr_->logger("ui"));
+   ui_->widgetTransactions->init(walletsMgr_, armory_, utxoReservationMgr_, signContainer_, applicationSettings_
+                                , logMgr_->logger("ui"));
    ui_->widgetTransactions->setEnabled(true);
 
    ui_->widgetTransactions->SetTransactionsModel(transactionsModel_);

--- a/BlockSettleUILib/CCTokenEntryDialog.cpp
+++ b/BlockSettleUILib/CCTokenEntryDialog.cpp
@@ -46,6 +46,7 @@ CCTokenEntryDialog::CCTokenEntryDialog(const std::shared_ptr<bs::sync::WalletsMa
    connect(ui_->pushButtonOk, &QPushButton::clicked, this, &CCTokenEntryDialog::accept);
    connect(ui_->pushButtonCancel, &QPushButton::clicked, this, &CCTokenEntryDialog::onCancel);
    connect(ui_->lineEditToken, &QLineEdit::textEdited, this, &CCTokenEntryDialog::tokenChanged);
+   connect(ui_->lineEditToken, &QLineEdit::returnPressed, this, &CCTokenEntryDialog::accept, Qt::QueuedConnection);
 
    connect(ccFileMgr_.get(), &CCFileManager::CCAddressSubmitted, this, &CCTokenEntryDialog::onCCAddrSubmitted, Qt::QueuedConnection);
    connect(ccFileMgr_.get(), &CCFileManager::CCInitialSubmitted, this, &CCTokenEntryDialog::onCCInitialSubmitted, Qt::QueuedConnection);

--- a/BlockSettleUILib/ChatUI/ChatOTCHelper.cpp
+++ b/BlockSettleUILib/ChatUI/ChatOTCHelper.cpp
@@ -32,14 +32,15 @@ void ChatOTCHelper::init(bs::network::otc::Env env
    , const std::shared_ptr<ArmoryConnection>& armory
    , const std::shared_ptr<SignContainer>& signContainer
    , const std::shared_ptr<AuthAddressManager> &authAddressManager
-   , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager)
+   , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
+   , const std::shared_ptr<ApplicationSettings>& applicationSettings)
 {
    loggerPtr_ = loggerPtr;
 
    OtcClientParams params;
    params.env = env;
    otcClient_ = new OtcClient(loggerPtr, walletsMgr, armory, signContainer, authAddressManager,
-      utxoReservationManager, std::move(params), this);
+      utxoReservationManager, applicationSettings, std::move(params), this);
 }
 
 OtcClient* ChatOTCHelper::client() const

--- a/BlockSettleUILib/ChatUI/ChatOTCHelper.h
+++ b/BlockSettleUILib/ChatUI/ChatOTCHelper.h
@@ -50,6 +50,7 @@ class ArmoryConnection;
 class AuthAddressManager;
 class OtcClient;
 class SignContainer;
+class ApplicationSettings;
 
 class ChatOTCHelper : public QObject {
    Q_OBJECT
@@ -63,7 +64,8 @@ public:
       , const std::shared_ptr<ArmoryConnection>& armory
       , const std::shared_ptr<SignContainer>& signContainer
       , const std::shared_ptr<AuthAddressManager> &authAddressManager
-      , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager);
+      , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
+      , const std::shared_ptr<ApplicationSettings>& applicationSettings);
 
    OtcClient* client() const;
 

--- a/BlockSettleUILib/ChatUI/ChatWidget.cpp
+++ b/BlockSettleUILib/ChatUI/ChatWidget.cpp
@@ -31,6 +31,7 @@
 #include "AssetManager.h"
 #include "ui_ChatWidget.h"
 #include "UtxoReservationManager.h"
+#include "ApplicationSettings.h"
 #include "chat.pb.h"
 
 using namespace bs::network;
@@ -100,13 +101,15 @@ void ChatWidget::init(const std::shared_ptr<ConnectionManager>& connectionManage
    , const std::shared_ptr<SignContainer>& signContainer
    , const std::shared_ptr<MDCallbacksQt> &mdCallbacks
    , const std::shared_ptr<AssetManager>& assetManager
-   , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager)
+   , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
+   , const std::shared_ptr<ApplicationSettings>& applicationSettings)
 {
    loggerPtr_ = loggerPtr;
 
    // OTC
    otcHelper_ = new ChatOTCHelper(this);
-   otcHelper_->init(env, loggerPtr, walletsMgr, armory, signContainer, authManager, utxoReservationManager);
+   otcHelper_->init(env, loggerPtr, walletsMgr, armory, signContainer,
+      authManager, utxoReservationManager, applicationSettings);
    otcWindowsManager_->init(walletsMgr, authManager, mdCallbacks, assetManager
       , armory, utxoReservationManager);
 

--- a/BlockSettleUILib/ChatUI/ChatWidget.h
+++ b/BlockSettleUILib/ChatUI/ChatWidget.h
@@ -31,6 +31,7 @@ class MDCallbacksQt;
 class OTCRequestViewModel;
 class OTCWindowsManager;
 class SignContainer;
+class ApplicationSettings;
 
 namespace Ui {
    class ChatWidget;
@@ -73,6 +74,7 @@ public:
       , const std::shared_ptr<MDCallbacksQt> &
       , const std::shared_ptr<AssetManager> &
       , const std::shared_ptr<bs::UTXOReservationManager> &
+      , const std::shared_ptr<ApplicationSettings>&
    );
 
    bs::network::otc::Peer *currentPeer() const;

--- a/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationRequestWidget.cpp
+++ b/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationRequestWidget.cpp
@@ -282,7 +282,16 @@ void OTCNegotiationRequestWidget::onParentAboutToHide()
 
 void OTCNegotiationRequestWidget::onCurrentWalletChanged()
 {
-   UiUtils::fillRecvAddressesComboBoxHDWallet(ui_->receivingAddressComboBox, getCurrentHDWallet(), true);
+   auto recvHdWallet = getCurrentHDWallet();
+   if (recvHdWallet->isHardwareWallet()) {
+      auto xbtGroup = recvHdWallet->getGroup(recvHdWallet->getXBTGroupType());
+      auto purpose = UiUtils::getSelectedHwPurpose(ui_->comboBoxXBTWallets);
+      UiUtils::fillRecvAddressesComboBox(ui_->receivingAddressComboBox, { xbtGroup->getLeaf(purpose) });
+   }
+   else {
+      UiUtils::fillRecvAddressesComboBoxHDWallet(ui_->receivingAddressComboBox, recvHdWallet, true);
+   }
+
    clearSelectedInputs();
    onUpdateBalances();
 }

--- a/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationResponseWidget.cpp
+++ b/BlockSettleUILib/ChatUI/OTCShieldWidgets/OTCNegotiationResponseWidget.cpp
@@ -252,7 +252,16 @@ void OTCNegotiationResponseWidget::onXbtInputsProcessed()
 
 void OTCNegotiationResponseWidget::onCurrentWalletChanged()
 {
-   UiUtils::fillRecvAddressesComboBoxHDWallet(ui_->receivingAddressComboBox, getCurrentHDWalletFromCombobox(ui_->comboBoxXBTWallets), true);
+   auto recvHdWallet = getCurrentHDWalletFromCombobox(ui_->comboBoxXBTWallets);
+   if (recvHdWallet->isHardwareWallet()) {
+      auto xbtGroup = recvHdWallet->getGroup(recvHdWallet->getXBTGroupType());
+      auto purpose = UiUtils::getSelectedHwPurpose(ui_->comboBoxXBTWallets);
+      UiUtils::fillRecvAddressesComboBox(ui_->receivingAddressComboBox, { xbtGroup->getLeaf(purpose) });
+   }
+   else {
+      UiUtils::fillRecvAddressesComboBoxHDWallet(ui_->receivingAddressComboBox, recvHdWallet, true);
+   }
+
    clearSelectedInputs();
    onUpdateBalances();
 }

--- a/BlockSettleUILib/CreateTransactionDialog.cpp
+++ b/BlockSettleUILib/CreateTransactionDialog.cpp
@@ -427,7 +427,7 @@ void CreateTransactionDialog::onTXSigned(unsigned int id, BinaryData signedTX, b
          return;
       }
 
-      detailedText = tr("Failed to communicate to armory to broadcast transaction. Maybe Armory is offline");
+      detailedText = tr("Failed to communicate to BlockSettleDB to broadcast transaction. Maybe BlockSettleDB is offline");
    }
    else {
       detailedText = bs::error::ErrorCodeToString(result);

--- a/BlockSettleUILib/CreateTransactionDialog.cpp
+++ b/BlockSettleUILib/CreateTransactionDialog.cpp
@@ -191,7 +191,7 @@ void CreateTransactionDialog::closeEvent(QCloseEvent *e)
    e->ignore();
 }
 
-int CreateTransactionDialog::SelectWallet(const std::string& walletId, int type)
+int CreateTransactionDialog::SelectWallet(const std::string& walletId, UiUtils::WalletsTypes type)
 {
    auto index = UiUtils::selectWalletInCombobox(comboBoxWallets(), walletId
       , static_cast<UiUtils::WalletsTypes>(type));

--- a/BlockSettleUILib/CreateTransactionDialog.cpp
+++ b/BlockSettleUILib/CreateTransactionDialog.cpp
@@ -191,9 +191,10 @@ void CreateTransactionDialog::closeEvent(QCloseEvent *e)
    e->ignore();
 }
 
-int CreateTransactionDialog::SelectWallet(const std::string& walletId)
+int CreateTransactionDialog::SelectWallet(const std::string& walletId, int type)
 {
-   auto index = UiUtils::selectWalletInCombobox(comboBoxWallets(), walletId);
+   auto index = UiUtils::selectWalletInCombobox(comboBoxWallets(), walletId
+      , static_cast<UiUtils::WalletsTypes>(type));
    if (index < 0) {
       const auto rootWallet = walletsManager_->getHDRootForLeaf(walletId);
       if (rootWallet) {

--- a/BlockSettleUILib/CreateTransactionDialog.h
+++ b/BlockSettleUILib/CreateTransactionDialog.h
@@ -61,7 +61,7 @@ public:
       , QWidget* parent);
    ~CreateTransactionDialog() noexcept override;
 
-   int SelectWallet(const std::string& walletId);
+   int SelectWallet(const std::string& walletId, int type);
 
    virtual bool switchModeRequested() const= 0;
    virtual std::shared_ptr<CreateTransactionDialog> SwithcMode() = 0;

--- a/BlockSettleUILib/CreateTransactionDialog.h
+++ b/BlockSettleUILib/CreateTransactionDialog.h
@@ -45,6 +45,10 @@ class TransactionOutputsModel;
 class UsedInputsModel;
 class XbtAmountValidator;
 
+namespace UiUtils {
+   enum WalletsTypes : int;
+}
+
 
 class CreateTransactionDialog : public QDialog
 {
@@ -61,7 +65,7 @@ public:
       , QWidget* parent);
    ~CreateTransactionDialog() noexcept override;
 
-   int SelectWallet(const std::string& walletId, int type);
+   int SelectWallet(const std::string& walletId, UiUtils::WalletsTypes type);
 
    virtual bool switchModeRequested() const= 0;
    virtual std::shared_ptr<CreateTransactionDialog> SwithcMode() = 0;

--- a/BlockSettleUILib/CreateTransactionDialogAdvanced.cpp
+++ b/BlockSettleUILib/CreateTransactionDialogAdvanced.cpp
@@ -1392,7 +1392,7 @@ void CreateTransactionDialogAdvanced::onExistingAddressSelectedForChange()
 
 void CreateTransactionDialogAdvanced::SetFixedWallet(const std::string& walletId, const std::function<void()> &cbInputsReset)
 {
-   const int idx = SelectWallet(walletId);
+   const int idx = SelectWallet(walletId, UiUtils::WalletsTypes::None);
    selectedWalletChanged(idx, true, cbInputsReset);
    ui_->comboBoxWallets->setEnabled(false);
 }
@@ -1404,7 +1404,7 @@ void CreateTransactionDialogAdvanced::setFixedGroupInputs(const std::shared_ptr<
    if (leaves.empty()) {
       return;
    }
-   SelectWallet(leaves.front()->walletId());
+   SelectWallet(leaves.front()->walletId(), UiUtils::WalletsTypes::None);
    ui_->comboBoxWallets->setEnabled(false);
    disableInputSelection();
    transactionData_->setGroupAndInputs(group, inputs, armory_->topBlock());
@@ -1580,7 +1580,8 @@ std::shared_ptr<CreateTransactionDialog> CreateTransactionDialogAdvanced::Swithc
       , walletsManager_, utxoReservationManager_, signContainer_
       , logger_, applicationSettings_, parentWidget());
 
-   simpleDialog->SelectWallet(UiUtils::getSelectedWalletId(ui_->comboBoxWallets));
+   simpleDialog->SelectWallet(UiUtils::getSelectedWalletId(ui_->comboBoxWallets),
+      UiUtils::getSelectedWalletType(ui_->comboBoxWallets));
 
    const auto recipientIdList = transactionData_->allRecipientIds();
 

--- a/BlockSettleUILib/CreateTransactionDialogSimple.cpp
+++ b/BlockSettleUILib/CreateTransactionDialogSimple.cpp
@@ -227,7 +227,8 @@ std::shared_ptr<CreateTransactionDialog> CreateTransactionDialogSimple::SwithcMo
       advancedDialog->SetImportedTransactions(offlineTransactions_);
    } else {
       // select wallet
-      advancedDialog->SelectWallet(UiUtils::getSelectedWalletId(ui_->comboBoxWallets));
+      advancedDialog->SelectWallet(UiUtils::getSelectedWalletId(ui_->comboBoxWallets),
+         UiUtils::getSelectedWalletType(ui_->comboBoxWallets));
 
       // set inputs and amounts
       auto address = ui_->lineEditAddress->text().trimmed();

--- a/BlockSettleUILib/Settings/ArmoryServersWidget.ui
+++ b/BlockSettleUILib/Settings/ArmoryServersWidget.ui
@@ -13,7 +13,7 @@
   <property name="sizeHint" stdset="0">
    <size>
     <width>922</width>
-    <height>469</height>
+    <height>459</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -397,7 +397,7 @@
                <item>
                 <widget class="QLabel" name="labelZmqPubKey_5">
                  <property name="text">
-                  <string>ArmoryDB Key</string>
+                  <string>BlockSettleDB Key</string>
                  </property>
                 </widget>
                </item>
@@ -422,7 +422,7 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>Optional when connecting to a public ArmoryDB</string>
+                  <string>Optional when connecting to a public BlockSettleDB</string>
                  </property>
                  <property name="styleSheet">
                   <string notr="true">image: url(&quot;:/resources/notification_info@2x.png&quot;);</string>

--- a/BlockSettleUILib/Settings/GeneralSettingsPage.cpp
+++ b/BlockSettleUILib/Settings/GeneralSettingsPage.cpp
@@ -56,7 +56,12 @@ void GeneralSettingsPage::display()
    ui_->checkBoxCloseToTray->setChecked(appSettings_->get<bool>(ApplicationSettings::closeToTray));
    ui_->checkBoxShowTxNotification->setChecked(appSettings_->get<bool>(ApplicationSettings::notifyOnTX));
    ui_->addvancedDialogByDefaultCheckBox->setChecked(appSettings_->get<bool>(ApplicationSettings::AdvancedTxDialogByDefault));
-   ui_->checkBox_subscribeToMdOnStart->setChecked(appSettings_->get<bool>(ApplicationSettings::SubscribeToMDOnStart));
+   ui_->subscribeToMdOnStartCheckBox->setChecked(appSettings_->get<bool>(ApplicationSettings::SubscribeToMDOnStart));
+   ui_->detailedSettlementTxDialogByDefaultCheckBox->setChecked(
+      appSettings_->get<bool>(ApplicationSettings::DetailedSettlementTxDialogByDefault));
+
+   
+   // DetailedSettlementTxDialogByDefault
 
    const auto cfg = appSettings_->GetLogsConfig();
    ui_->logFileName->setText(QString::fromStdString(cfg.at(0).fileName));
@@ -101,7 +106,10 @@ void GeneralSettingsPage::apply()
       ui_->addvancedDialogByDefaultCheckBox->isChecked());
 
    appSettings_->set(ApplicationSettings::SubscribeToMDOnStart
-      , ui_->checkBox_subscribeToMdOnStart->isChecked());
+      , ui_->subscribeToMdOnStartCheckBox->isChecked());
+
+   appSettings_->set(ApplicationSettings::DetailedSettlementTxDialogByDefault
+      , ui_->detailedSettlementTxDialogByDefaultCheckBox->isChecked());
 
    auto cfg = appSettings_->GetLogsConfig();
 

--- a/BlockSettleUILib/Settings/GeneralSettingsPage.ui
+++ b/BlockSettleUILib/Settings/GeneralSettingsPage.ui
@@ -58,9 +58,16 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="checkBox_subscribeToMdOnStart">
+       <widget class="QCheckBox" name="subscribeToMdOnStartCheckBox">
         <property name="text">
          <string>Activate Market Data at launch</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="detailedSettlementTxDialogByDefaultCheckBox">
+        <property name="text">
+         <string>Use detailed settlement dialog by default</string>
         </property>
        </widget>
       </item>
@@ -458,7 +465,7 @@
  </widget>
  <tabstops>
   <tabstop>addvancedDialogByDefaultCheckBox</tabstop>
-  <tabstop>checkBox_subscribeToMdOnStart</tabstop>
+  <tabstop>subscribeToMdOnStartCheckBox</tabstop>
   <tabstop>logFileName</tabstop>
   <tabstop>chooseLogFileBtn</tabstop>
   <tabstop>logLevel</tabstop>

--- a/BlockSettleUILib/Settings/NetworkSettingsPage.cpp
+++ b/BlockSettleUILib/Settings/NetworkSettingsPage.cpp
@@ -57,7 +57,7 @@ NetworkSettingsPage::NetworkSettingsPage(QWidget* parent)
       QVBoxLayout *l = new QVBoxLayout(d);
       l->setContentsMargins(0,0,0,0);
       d->setLayout(l);
-      d->setWindowTitle(tr("ArmoryDB connection"));
+      d->setWindowTitle(tr("BlockSettleDB connection"));
       d->resize(847, 593);
 
       ArmoryServersWidget *armoryServersWidget = new ArmoryServersWidget(armoryServersProvider_, appSettings_, this);
@@ -90,7 +90,7 @@ NetworkSettingsPage::NetworkSettingsPage(QWidget* parent)
    });
    connect(ui_->pushButtonArmoryServerKeySave, &QPushButton::clicked, this, [this](){
       QString fileName = QFileDialog::getSaveFileName(this
-                                   , tr("Save Armory Public Key")
+                                   , tr("Save BlockSettleDB Public Key")
                                    , QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + QDir::separator() + QStringLiteral("Armory_Server_Public_Key.pub")
                                    , tr("Key files (*.pub)"));
 

--- a/BlockSettleUILib/Settings/NetworkSettingsPage.ui
+++ b/BlockSettleUILib/Settings/NetworkSettingsPage.ui
@@ -38,7 +38,7 @@
       </size>
      </property>
      <property name="title">
-      <string>ARMORY DATABASE</string>
+      <string>BLOCKSETTLE DATABASE</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_6">
       <property name="spacing">
@@ -101,7 +101,7 @@
             </size>
            </property>
            <property name="text">
-            <string>ArmoryDB Server</string>
+            <string>BlockSettleDB Server</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -207,7 +207,7 @@
       </size>
      </property>
      <property name="title">
-      <string>ARMORYDB DETAILS</string>
+      <string>BLOCKSETTLEDB DETAILS</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_4">
       <property name="spacing">

--- a/BlockSettleUILib/Settings/SignerSettings.cpp
+++ b/BlockSettleUILib/Settings/SignerSettings.cpp
@@ -407,12 +407,6 @@ void SignerSettings::setTwoWaySignerAuth(bool val)
    }
 }
 
-void SignerSettings::setDefaultSettlDialogExpandedState(bool state)
-{
-   defaultSettlDialogExpandedState_ = state;
-   emit defaultSettlDialogExpandedStateChanged();
-}
-
 QString SignerSettings::secondsToIntervalStr(int s)
 {
    QString result;

--- a/BlockSettleUILib/Settings/SignerSettings.h
+++ b/BlockSettleUILib/Settings/SignerSettings.h
@@ -43,7 +43,6 @@ class SignerSettings : public QObject
    Q_PROPERTY(bool hideEidInfoBox READ hideEidInfoBox WRITE setHideEidInfoBox NOTIFY hideEidInfoBoxChanged)
    Q_PROPERTY(QStringList trustedTerminals READ trustedTerminals WRITE setTrustedTerminals NOTIFY trustedTerminalsChanged)
    Q_PROPERTY(bool twoWaySignerAuth READ twoWaySignerAuth WRITE setTwoWaySignerAuth NOTIFY twoWaySignerAuthChanged)
-   Q_PROPERTY(bool defaultSettlDialogExpandedState READ defaultSettlDialogExpandedState WRITE setDefaultSettlDialogExpandedState NOTIFY defaultSettlDialogExpandedStateChanged)
 
 public:
    SignerSettings();
@@ -84,7 +83,6 @@ public:
    QString dirDocuments() const;
    bs::signer::ui::RunMode runMode() const { return runMode_; }
    bool closeHeadless() const { return true; }
-   bool defaultSettlDialogExpandedState() { return defaultSettlDialogExpandedState_; }
 
    void setOffline(bool val);
    void setTestNet(bool val);
@@ -101,7 +99,6 @@ public:
    void setHideEidInfoBox(bool val);
    void setTrustedTerminals(const QStringList &val);
    void setTwoWaySignerAuth(bool val);
-   void setDefaultSettlDialogExpandedState(bool state);
    using Settings = Blocksettle::Communication::signer::Settings;
    const std::unique_ptr<Settings> &get() const { return d_; }
 
@@ -126,7 +123,6 @@ signals:
    void trustedTerminalsChanged();
    void twoWaySignerAuthChanged();
    void changed(int);
-   void defaultSettlDialogExpandedStateChanged();
 
 private:
    void settingChanged(int setting);
@@ -141,8 +137,6 @@ private:
    bs::signer::ui::RunMode runMode_{};
    std::unique_ptr<Settings> d_;
 
-   // Temporary session settings
-   bool defaultSettlDialogExpandedState_ = false;
 };
 
 

--- a/BlockSettleUILib/Settings/SignerSettingsPage.cpp
+++ b/BlockSettleUILib/Settings/SignerSettingsPage.cpp
@@ -46,7 +46,7 @@ SignerSettingsPage::SignerSettingsPage(QWidget* parent)
    });
    connect(ui_->pushButtonTerminalKeySave, &QPushButton::clicked, this, [this](){
       QString fileName = QFileDialog::getSaveFileName(this
-                                   , tr("Save Armory Public Key")
+                                   , tr("Save BlockSettleDB Public Key")
                                    , QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + QDir::separator() + QStringLiteral("Terminal_Public_Key.pub")
                                    , tr("Key files (*.pub)"));
 

--- a/BlockSettleUILib/Trading/AutoSignQuoteWidget.cpp
+++ b/BlockSettleUILib/Trading/AutoSignQuoteWidget.cpp
@@ -99,11 +99,13 @@ void AutoSignQuoteWidget::onAutoSignStateChanged()
 
 void AutoSignQuoteWidget::onAutoSignQuoteAvailChanged()
 {
-   ui_->groupBoxAutoSign->setEnabled(autoSignQuoteProvider_->autoSignQuoteAvailable());
-
    ui_->checkBoxAQ->setChecked(false);
-
    ui_->labelAutoSignWalletName->setText(autoSignQuoteProvider_->getAutoSignWalletName());
+
+   const bool enableWidget = autoSignQuoteProvider_->autoSignQuoteAvailable();
+   ui_->groupBoxAutoSign->setEnabled(enableWidget);
+   ui_->checkBoxAutoSign->setEnabled(enableWidget);
+   ui_->checkBoxAQ->setEnabled(enableWidget);
 }
 
 void AutoSignQuoteWidget::onAqScriptLoaded()

--- a/BlockSettleUILib/Trading/DealerCCSettlementContainer.cpp
+++ b/BlockSettleUILib/Trading/DealerCCSettlementContainer.cpp
@@ -36,8 +36,9 @@ DealerCCSettlementContainer::DealerCCSettlementContainer(const std::shared_ptr<s
    , const std::shared_ptr<ArmoryConnection> &armory
    , const std::shared_ptr<bs::sync::WalletsManager> &walletsMgr
    , std::unique_ptr<bs::hd::Purpose> walletPurpose
-   , bs::UtxoReservationToken utxoRes)
-   : bs::SettlementContainer(std::move(utxoRes), std::move(walletPurpose))
+   , bs::UtxoReservationToken utxoRes
+   , bool expandTxDialogInfo)
+   : bs::SettlementContainer(std::move(utxoRes), std::move(walletPurpose), expandTxDialogInfo)
    , logger_(logger)
    , order_(order)
    , lotSize_(lotSize)

--- a/BlockSettleUILib/Trading/DealerCCSettlementContainer.h
+++ b/BlockSettleUILib/Trading/DealerCCSettlementContainer.h
@@ -47,7 +47,8 @@ public:
       , const std::shared_ptr<ArmoryConnection> &
       , const std::shared_ptr<bs::sync::WalletsManager> &walletsMgr
       , std::unique_ptr<bs::hd::Purpose> walletPurpose
-      , bs::UtxoReservationToken utxoRes);
+      , bs::UtxoReservationToken utxoRes
+      , bool expandTxDialogInfo);
    ~DealerCCSettlementContainer() override;
 
    bool startSigning(QDateTime timestamp);

--- a/BlockSettleUILib/Trading/DealerXBTSettlementContainer.cpp
+++ b/BlockSettleUILib/Trading/DealerXBTSettlementContainer.cpp
@@ -42,8 +42,9 @@ DealerXBTSettlementContainer::DealerXBTSettlementContainer(const std::shared_ptr
    , const bs::Address &recvAddr
    , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
    , std::unique_ptr<bs::hd::Purpose> walletPurpose
-   , bs::UtxoReservationToken utxoRes)
-   : bs::SettlementContainer(std::move(utxoRes), std::move(walletPurpose))
+   , bs::UtxoReservationToken utxoRes
+   , bool expandTxDialogInfo)
+   : bs::SettlementContainer(std::move(utxoRes), std::move(walletPurpose), expandTxDialogInfo)
    , order_(order)
    , weSellXbt_((order.side == bs::network::Side::Buy) != (order.product == bs::network::XbtCurrency))
    , amount_((order.product != bs::network::XbtCurrency) ? order.quantity / order.price : order.quantity)

--- a/BlockSettleUILib/Trading/DealerXBTSettlementContainer.cpp
+++ b/BlockSettleUILib/Trading/DealerXBTSettlementContainer.cpp
@@ -299,7 +299,7 @@ void DealerXBTSettlementContainer::onUnsignedPayinRequested(const std::string& s
       args.inputXbtWallets.push_back(leaf);
    }
    else {
-      for (const auto &leaf : xbtWallet_->getGroup(xbtWallet_->getXBTGroupType())->getLeaves()) {
+      for (const auto &leaf : xbtGroup->getLeaves()) {
          args.inputXbtWallets.push_back(leaf);
       }
    }
@@ -360,7 +360,16 @@ void DealerXBTSettlementContainer::onSignedPayoutRequested(const std::string& se
    initTradesArgs(args, settlementId);
    args.payinTxId = payinHash;
    args.recvAddr = recvAddr_;
-   args.outputXbtWallet = xbtWallet_->getGroup(bs::sync::hd::Wallet::getXBTGroupType())->getLeaves().at(0);
+
+   const auto xbtGroup = xbtWallet_->getGroup(xbtWallet_->getXBTGroupType());
+   if (xbtWallet_->isHardwareWallet()) {
+      assert(walletPurpose_);
+      const auto leaf = xbtGroup->getLeaf(*walletPurpose_);
+      args.outputXbtWallet = leaf;
+   }
+   else {
+      args.outputXbtWallet = xbtGroup->getLeaves().at(0);
+   }
 
    auto payoutCb = bs::tradeutils::PayoutResultCb([this, payinHash, timestamp, handle = validityFlag_.handle()]
       (bs::tradeutils::PayoutResult result)

--- a/BlockSettleUILib/Trading/DealerXBTSettlementContainer.h
+++ b/BlockSettleUILib/Trading/DealerXBTSettlementContainer.h
@@ -58,7 +58,8 @@ public:
       , const bs::Address &recvAddr
       , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
       , std::unique_ptr<bs::hd::Purpose> walletPurpose
-      , bs::UtxoReservationToken utxoRes);
+      , bs::UtxoReservationToken utxoRes
+      , bool expandTxDialogInfo);
    ~DealerXBTSettlementContainer() override;
 
    bool cancel() override;

--- a/BlockSettleUILib/Trading/OtcClient.cpp
+++ b/BlockSettleUILib/Trading/OtcClient.cpp
@@ -29,6 +29,7 @@
 #include "Wallets/SyncHDLeaf.h"
 #include "Wallets/SyncHDWallet.h"
 #include "Wallets/SyncWalletsManager.h"
+#include "ApplicationSettings.h"
 
 #include "bs_proxy_terminal_pb.pb.h"
 #include "otc.pb.h"
@@ -116,7 +117,8 @@ namespace {
    const auto kStartOtcTimeout = std::chrono::seconds(10);
 
    bs::sync::PasswordDialogData toPasswordDialogData(const OtcClientDeal &deal
-      , const bs::core::wallet::TXSignRequest &signRequest, QDateTime timestamp)
+      , const bs::core::wallet::TXSignRequest &signRequest
+      , QDateTime timestamp, bool expandTxInfo)
    {
       double price = fromCents(deal.price);
 
@@ -154,13 +156,16 @@ namespace {
       // Set timestamp that will be used by auth eid server to update timers.
       dialogData.setValue(PasswordDialogData::DurationTimestamp, static_cast<int>(timestamp.toSecsSinceEpoch()));
 
+      dialogData.setValue(PasswordDialogData::ExpandTxInfo, expandTxInfo);
+
       return dialogData;
    }
 
    bs::sync::PasswordDialogData toPasswordDialogDataPayin(const OtcClientDeal &deal
-      , const bs::core::wallet::TXSignRequest &signRequest, QDateTime timestamp)
+      , const bs::core::wallet::TXSignRequest &signRequest
+      , QDateTime timestamp, bool expandTxInfo)
    {
-      auto dialogData = toPasswordDialogData(deal, signRequest, timestamp);
+      auto dialogData = toPasswordDialogData(deal, signRequest, timestamp, expandTxInfo);
       dialogData.setValue(PasswordDialogData::SettlementPayInVisible, true);
       dialogData.setValue(PasswordDialogData::Title, QObject::tr("Settlement Pay-In"));
       dialogData.setValue(PasswordDialogData::DurationTotal, int(std::chrono::duration_cast<std::chrono::milliseconds>(otc::payinTimeout()).count()));
@@ -169,9 +174,10 @@ namespace {
    }
 
    bs::sync::PasswordDialogData toPasswordDialogDataPayout(const OtcClientDeal &deal
-      , const bs::core::wallet::TXSignRequest &signRequest, QDateTime timestamp)
+      , const bs::core::wallet::TXSignRequest &signRequest
+      , QDateTime timestamp, bool expandTxInfo)
    {
-      auto dialogData = toPasswordDialogData(deal, signRequest, timestamp);
+      auto dialogData = toPasswordDialogData(deal, signRequest, timestamp, expandTxInfo);
       dialogData.setValue(PasswordDialogData::SettlementPayOutVisible, true);
       dialogData.setValue(PasswordDialogData::Title, QObject::tr("Settlement Pay-Out"));
       dialogData.setValue(PasswordDialogData::DurationTotal, int(std::chrono::duration_cast<std::chrono::milliseconds>(otc::payoutTimeout()).count()));
@@ -216,6 +222,7 @@ OtcClient::OtcClient(const std::shared_ptr<spdlog::logger> &logger
    , const std::shared_ptr<SignContainer> &signContainer
    , const std::shared_ptr<AuthAddressManager> &authAddressManager
    , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
+   , const std::shared_ptr<ApplicationSettings>& applicationSettings
    , OtcClientParams params
    , QObject *parent)
    : QObject (parent)
@@ -225,6 +232,7 @@ OtcClient::OtcClient(const std::shared_ptr<spdlog::logger> &logger
    , signContainer_(signContainer)
    , authAddressManager_(authAddressManager)
    , utxoReservationManager_(utxoReservationManager)
+   , applicationSettings_(applicationSettings)
    , params_(std::move(params))
 {
    connect(signContainer.get(), &SignContainer::TXSigned, this, &OtcClient::onTxSigned);
@@ -1294,7 +1302,7 @@ void OtcClient::processPbUpdateOtcState(const ProxyTerminalPb::Response_UpdateOt
             settlData.cpPublicKey = deal->cpPubKey;
             settlData.ownKeyFirst = true;
 
-            auto payoutInfo = toPasswordDialogDataPayout(*deal, deal->payout, timestamp);
+            auto payoutInfo = toPasswordDialogDataPayout(*deal, deal->payout, timestamp, expandTxDialog());
             auto reqId = signContainer_->signSettlementPayoutTXRequest(deal->payout, settlData, payoutInfo);
             signRequestIds_[reqId] = deal->settlementId;
             deal->payoutReqId = reqId;
@@ -1323,7 +1331,10 @@ void OtcClient::processPbUpdateOtcState(const ProxyTerminalPb::Response_UpdateOt
          if (deal->side == otc::Side::Sell) {
             assert(deal->payin.isValid());
 
-            auto payinInfo = toPasswordDialogDataPayin(*deal, deal->payin, timestamp);
+            const bool expandTxInfo = applicationSettings_->get<bool>(
+               ApplicationSettings::DetailedSettlementTxDialogByDefault);
+
+            auto payinInfo = toPasswordDialogDataPayin(*deal, deal->payin, timestamp, expandTxDialog());
             auto reqId = signContainer_->signSettlementTXRequest(deal->payin, payinInfo);
             signRequestIds_[reqId] = deal->settlementId;
             deal->payinReqId = reqId;
@@ -1789,4 +1800,10 @@ void OtcClient::initTradesArgs(bs::tradeutils::Args &args, Peer *peer, const std
    if (utxoReservationManager_) {
       args.feeRatePb_ = utxoReservationManager_->feeRatePb();
    }
+}
+
+bool OtcClient::expandTxDialog() const
+{
+   return applicationSettings_->get<bool>(
+      ApplicationSettings::DetailedSettlementTxDialogByDefault);
 }

--- a/BlockSettleUILib/Trading/OtcClient.h
+++ b/BlockSettleUILib/Trading/OtcClient.h
@@ -75,6 +75,7 @@ namespace bs {
 
 class ArmoryConnection;
 class AuthAddressManager;
+class ApplicationSettings;
 class SignContainer;
 struct OtcClientDeal;
 
@@ -95,6 +96,7 @@ public:
       , const std::shared_ptr<SignContainer> &signContainer
       , const std::shared_ptr<AuthAddressManager> &authAddressManager
       , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
+      , const std::shared_ptr<ApplicationSettings>& applicationSettings
       , OtcClientParams params
       , QObject *parent = nullptr);
    ~OtcClient() override;
@@ -192,6 +194,8 @@ private:
 
    void initTradesArgs(bs::tradeutils::Args &args, bs::network::otc::Peer *peer, const std::string &settlementId);
 
+   bool expandTxDialog() const;
+
    std::shared_ptr<spdlog::logger> logger_;
 
    std::shared_ptr<bs::sync::WalletsManager> walletsMgr_;
@@ -199,6 +203,7 @@ private:
    std::shared_ptr<SignContainer> signContainer_;
    std::shared_ptr<AuthAddressManager> authAddressManager_;
    std::shared_ptr<bs::UTXOReservationManager> utxoReservationManager_;
+   std::shared_ptr<ApplicationSettings> applicationSettings_;
 
    std::string ownContactId_;
 

--- a/BlockSettleUILib/Trading/RFQDealerReply.cpp
+++ b/BlockSettleUILib/Trading/RFQDealerReply.cpp
@@ -799,9 +799,10 @@ void RFQDealerReply::submitReply(const bs::network::QuoteReqNotification &qrn, d
 
 void RFQDealerReply::updateWalletsList(int walletsFlags)
 {
-   auto oldWalletId = ui_->comboBoxXbtWallet->currentData(UiUtils::WalletIdRole).toString().toStdString();
+   auto oldWalletId = UiUtils::getSelectedWalletId(ui_->comboBoxXbtWallet);
+   auto oldType = UiUtils::getSelectedWalletType(ui_->comboBoxXbtWallet);
    int defaultIndex = UiUtils::fillHDWalletsComboBox(ui_->comboBoxXbtWallet, walletsManager_, walletsFlags);
-   int oldIndex = UiUtils::selectWalletInCombobox(ui_->comboBoxXbtWallet, oldWalletId);
+   int oldIndex = UiUtils::selectWalletInCombobox(ui_->comboBoxXbtWallet, oldWalletId, oldType);
    if (oldIndex < 0) {
       ui_->comboBoxXbtWallet->setCurrentIndex(defaultIndex);
    }

--- a/BlockSettleUILib/Trading/RFQDialog.cpp
+++ b/BlockSettleUILib/Trading/RFQDialog.cpp
@@ -174,11 +174,14 @@ std::shared_ptr<bs::SettlementContainer> RFQDialog::newXBTcontainer()
       return nullptr;
    }
 
+   const bool expandTxInfo = appSettings_->get<bool>(
+      ApplicationSettings::DetailedSettlementTxDialogByDefault);
+
    try {
       xbtSettlContainer_ = std::make_shared<ReqXBTSettlementContainer>(logger_
          , authAddressManager_, signContainer_, armory_, xbtWallet_, walletsManager_
          , rfq_, quote_, authAddr_, fixedXbtInputs_, std::move(fixedXbtUtxoRes_), utxoReservationManager_
-         , std::move(walletPurpose_), recvXbtAddrIfSet_);
+         , std::move(walletPurpose_), recvXbtAddrIfSet_, expandTxInfo);
 
       connect(xbtSettlContainer_.get(), &ReqXBTSettlementContainer::settlementAccepted
          , this, &RFQDialog::onXBTSettlementAccepted);
@@ -217,10 +220,13 @@ void RFQDialog::hideIfNoRemoteSignerMode()
 
 std::shared_ptr<bs::SettlementContainer> RFQDialog::newCCcontainer()
 {
+   const bool expandTxInfo = appSettings_->get<bool>(
+      ApplicationSettings::DetailedSettlementTxDialogByDefault);
+
    try {
       ccSettlContainer_ = std::make_shared<ReqCCSettlementContainer>(logger_
          , signContainer_, armory_, assetMgr_, walletsManager_, rfq_, quote_, xbtWallet_,
-         fixedXbtInputs_, utxoReservationManager_, std::move(walletPurpose_), std::move(ccUtxoRes_));
+         fixedXbtInputs_, utxoReservationManager_, std::move(walletPurpose_), std::move(ccUtxoRes_), expandTxInfo);
 
       connect(ccSettlContainer_.get(), &ReqCCSettlementContainer::txSigned
          , this, &RFQDialog::onCCTxSigned);

--- a/BlockSettleUILib/Trading/RFQReplyWidget.cpp
+++ b/BlockSettleUILib/Trading/RFQReplyWidget.cpp
@@ -284,6 +284,9 @@ void RFQReplyWidget::onOrder(const bs::network::Order &order)
       return;
    }
 
+   const bool expandTxInfo = appSettings_->get<bool>(
+      ApplicationSettings::DetailedSettlementTxDialogByDefault);
+
    if (order.status == bs::network::Order::Pending) {
       if (order.assetType == bs::network::Asset::PrivateMarket) {
          const auto &quoteReqId = quoteProvider_->getQuoteReqId(order.quoteId);
@@ -300,7 +303,8 @@ void RFQReplyWidget::onOrder(const bs::network::Order &order)
          try {
             const auto settlContainer = std::make_shared<DealerCCSettlementContainer>(logger_, order, quoteReqId
                , assetManager_->getCCLotSize(order.product), assetManager_->getCCGenesisAddr(order.product)
-               , sr.recipientAddress, sr.xbtWallet, signingContainer_, armory_, walletsManager_, std::move(sr.walletPurpose), std::move(sr.utxoRes));
+               , sr.recipientAddress, sr.xbtWallet, signingContainer_, armory_, walletsManager_
+               , std::move(sr.walletPurpose), std::move(sr.utxoRes), expandTxInfo);
             connect(settlContainer.get(), &DealerCCSettlementContainer::signTxRequest, this, &RFQReplyWidget::saveTxData);
             connect(settlContainer.get(), &DealerCCSettlementContainer::error, this, &RFQReplyWidget::onTransactionError);
             connect(settlContainer.get(), &DealerCCSettlementContainer::cancelTrade, this, &RFQReplyWidget::cancelCCTrade);
@@ -336,7 +340,7 @@ void RFQReplyWidget::onOrder(const bs::network::Order &order)
             const auto settlContainer = std::make_shared<DealerXBTSettlementContainer>(logger_, order
                , walletsManager_, reply.xbtWallet, quoteProvider_, signingContainer_, armory_, authAddressManager_
                , reply.authAddr, reply.utxosPayinFixed, recvXbtAddr, utxoReservationManager_,
-               std::move(reply.walletPurpose), std::move(reply.utxoRes));
+               std::move(reply.walletPurpose), std::move(reply.utxoRes), expandTxInfo);
 
             connect(settlContainer.get(), &DealerXBTSettlementContainer::sendUnsignedPayinToPB, this, &RFQReplyWidget::sendUnsignedPayinToPB);
             connect(settlContainer.get(), &DealerXBTSettlementContainer::sendSignedPayinToPB, this, &RFQReplyWidget::sendSignedPayinToPB);

--- a/BlockSettleUILib/Trading/RFQTicketXBT.cpp
+++ b/BlockSettleUILib/Trading/RFQTicketXBT.cpp
@@ -321,7 +321,14 @@ void RFQTicketXBT::fillRecvAddresses()
 {
    auto recvWallet = getRecvXbtWallet();
    if (recvWallet) {
-      UiUtils::fillRecvAddressesComboBoxHDWallet(ui_->receivingAddressComboBox, recvWallet, true);
+      if (recvWallet->isHardwareWallet()) {
+         auto xbtGroup = recvWallet->getGroup(recvWallet->getXBTGroupType());
+         auto purpose =  UiUtils::getSelectedHwPurpose(ui_->comboBoxXBTWalletsRecv);
+         UiUtils::fillRecvAddressesComboBox(ui_->receivingAddressComboBox, { xbtGroup->getLeaf(purpose) });
+      }
+      else {
+         UiUtils::fillRecvAddressesComboBoxHDWallet(ui_->receivingAddressComboBox, recvWallet, true);
+      }
    }
 }
 

--- a/BlockSettleUILib/Trading/ReqCCSettlementContainer.cpp
+++ b/BlockSettleUILib/Trading/ReqCCSettlementContainer.cpp
@@ -35,8 +35,9 @@ ReqCCSettlementContainer::ReqCCSettlementContainer(const std::shared_ptr<spdlog:
    , const std::map<UTXO, std::string> &manualXbtInputs
    , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
    , std::unique_ptr<bs::hd::Purpose> walletPurpose
-   , bs::UtxoReservationToken utxoRes)
-   : bs::SettlementContainer(std::move(utxoRes), std::move(walletPurpose))
+   , bs::UtxoReservationToken utxoRes
+   , bool expandTxDialogInfo)
+   : bs::SettlementContainer(std::move(utxoRes), std::move(walletPurpose), expandTxDialogInfo)
    , logger_(logger)
    , signingContainer_(container)
    , xbtWallet_(xbtWallet)

--- a/BlockSettleUILib/Trading/ReqCCSettlementContainer.h
+++ b/BlockSettleUILib/Trading/ReqCCSettlementContainer.h
@@ -48,7 +48,8 @@ public:
       , const std::map<UTXO, std::string> &manualXbtInputs
       , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
       , std::unique_ptr<bs::hd::Purpose> walletPurpose
-      , bs::UtxoReservationToken utxoRes);
+      , bs::UtxoReservationToken utxoRes
+      , bool expandTxDialogInfo);
    ~ReqCCSettlementContainer() override;
 
    bool cancel() override;

--- a/BlockSettleUILib/Trading/ReqXBTSettlementContainer.cpp
+++ b/BlockSettleUILib/Trading/ReqXBTSettlementContainer.cpp
@@ -45,8 +45,9 @@ ReqXBTSettlementContainer::ReqXBTSettlementContainer(const std::shared_ptr<spdlo
    , bs::UtxoReservationToken utxoRes
    , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
    , std::unique_ptr<bs::hd::Purpose> walletPurpose
-   , const bs::Address &recvAddrIfSet)
-   : bs::SettlementContainer(std::move(utxoRes), std::move(walletPurpose))
+   , const bs::Address &recvAddrIfSet
+   , bool expandTxDialogInfo)
+   : bs::SettlementContainer(std::move(utxoRes), std::move(walletPurpose), expandTxDialogInfo)
    , logger_(logger)
    , authAddrMgr_(authAddrMgr)
    , walletsMgr_(walletsMgr)

--- a/BlockSettleUILib/Trading/ReqXBTSettlementContainer.cpp
+++ b/BlockSettleUILib/Trading/ReqXBTSettlementContainer.cpp
@@ -324,7 +324,7 @@ void ReqXBTSettlementContainer::onUnsignedPayinRequested(const std::string& sett
       args.inputXbtWallets.push_back(leaf);
    }
    else {
-      for (const auto &leaf : xbtWallet_->getGroup(xbtWallet_->getXBTGroupType())->getLeaves()) {
+      for (const auto &leaf : xbtGroup->getLeaves()) {
          args.inputXbtWallets.push_back(leaf);
       }
    }
@@ -394,7 +394,16 @@ void ReqXBTSettlementContainer::onSignedPayoutRequested(const std::string& settl
    initTradesArgs(args, settlementId);
    args.payinTxId = payinHash;
    args.recvAddr = recvAddrIfSet_;
-   args.outputXbtWallet = xbtWallet_->getGroup(xbtWallet_->getXBTGroupType())->getLeaves().at(0);
+
+   const auto xbtGroup = xbtWallet_->getGroup(xbtWallet_->getXBTGroupType());
+   if (xbtWallet_->isHardwareWallet()) {
+      assert(walletPurpose_);
+      const auto leaf = xbtGroup->getLeaf(*walletPurpose_);
+      args.outputXbtWallet = leaf;
+   }
+   else {
+      args.outputXbtWallet = xbtGroup->getLeaves().at(0);
+   }
 
    auto payoutCb = bs::tradeutils::PayoutResultCb([this, payinHash, timestamp, handle = validityFlag_.handle()]
       (bs::tradeutils::PayoutResult result)

--- a/BlockSettleUILib/Trading/ReqXBTSettlementContainer.h
+++ b/BlockSettleUILib/Trading/ReqXBTSettlementContainer.h
@@ -54,7 +54,8 @@ public:
       , bs::UtxoReservationToken utxoRes
       , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
       , std::unique_ptr<bs::hd::Purpose> walletPurpose
-      , const bs::Address &recvAddrIfSet);
+      , const bs::Address &recvAddrIfSet
+      , bool expandTxDialogInfo);
    ~ReqXBTSettlementContainer() override;
 
    bool cancel() override;

--- a/BlockSettleUILib/Trading/SettlementContainer.cpp
+++ b/BlockSettleUILib/Trading/SettlementContainer.cpp
@@ -20,10 +20,12 @@ namespace {
 
 } // namespace
 
-SettlementContainer::SettlementContainer(UtxoReservationToken utxoRes, std::unique_ptr<bs::hd::Purpose> walletPurpose)
+SettlementContainer::SettlementContainer(UtxoReservationToken utxoRes,
+   std::unique_ptr<bs::hd::Purpose> walletPurpose, bool expandTxDialogInfo)
    : QObject(nullptr)
    , utxoRes_(std::move(utxoRes))
    , walletPurpose_(std::move(walletPurpose))
+   , expandTxDialogInfo_(expandTxDialogInfo)
 {}
 
 SettlementContainer::~SettlementContainer()
@@ -50,6 +52,7 @@ sync::PasswordDialogData SettlementContainer::toPasswordDialogData(QDateTime tim
    info.setValue(PasswordDialogData::Security, security());
    info.setValue(PasswordDialogData::Product, product());
    info.setValue(PasswordDialogData::Side, tr(bs::network::Side::toString(side())));
+   info.setValue(PasswordDialogData::ExpandTxInfo, expandTxDialogInfo_);
 
    return info;
 }

--- a/BlockSettleUILib/Trading/SettlementContainer.h
+++ b/BlockSettleUILib/Trading/SettlementContainer.h
@@ -32,7 +32,8 @@ namespace bs {
       Q_OBJECT
    public:
       explicit SettlementContainer(bs::UtxoReservationToken utxoRes,
-         std::unique_ptr<bs::hd::Purpose> walletPurpose);
+         std::unique_ptr<bs::hd::Purpose> walletPurpose,
+         bool expandTxDialogInfo);
       ~SettlementContainer() override;
 
       virtual bool cancel() = 0;
@@ -78,6 +79,7 @@ namespace bs {
       ValidityFlag validityFlag_;
       bs::UtxoReservationToken utxoRes_;
       std::unique_ptr<bs::hd::Purpose> walletPurpose_;
+      bool expandTxDialogInfo_{};
 
    private:
       QTimer   timer_;

--- a/BlockSettleUILib/TransactionsWidget.cpp
+++ b/BlockSettleUILib/TransactionsWidget.cpp
@@ -303,6 +303,7 @@ void TransactionsWidget::init(const std::shared_ptr<bs::sync::WalletsManager> &w
                               , const std::shared_ptr<ArmoryConnection> &armory
                               , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
                               , const std::shared_ptr<WalletSignerContainer> &signContainer
+                              , const std::shared_ptr<ApplicationSettings> &appSettings
                               , const std::shared_ptr<spdlog::logger> &logger)
 
 {
@@ -310,6 +311,7 @@ void TransactionsWidget::init(const std::shared_ptr<bs::sync::WalletsManager> &w
    armory_ = armory;
    utxoReservationManager_ = utxoReservationManager;
    signContainer_ = signContainer;
+   appSettings_ = appSettings;
    logger_ = logger;
 
    connect(walletsManager_.get(), &bs::sync::WalletsManager::walletChanged, this, &TransactionsWidget::walletsChanged);
@@ -380,11 +382,6 @@ void TransactionsWidget::onProgressInited(int start, int end)
 void TransactionsWidget::onProgressUpdated(int value)
 {
    ui_->progressBar->setValue(value);
-}
-
-void TransactionsWidget::setAppSettings(std::shared_ptr<ApplicationSettings> appSettings)
-{
-   appSettings_ = appSettings;
 }
 
 void TransactionsWidget::shortcutActivated(ShortcutType s)
@@ -645,6 +642,9 @@ void TransactionsWidget::onRevokeSettlement()
          dlgData.setValue(PasswordDialogData::RequesterAuthAddressVerified, true);
          dlgData.setValue(PasswordDialogData::ResponderAuthAddressVerified, true);
          dlgData.setValue(PasswordDialogData::SigningAllowed, true);
+
+         dlgData.setValue(PasswordDialogData::ExpandTxInfo,
+            appSettings_->get(ApplicationSettings::AdvancedTxDialogByDefault).toBool());
 
          const auto amount = args->amount.GetValueBitcoin();
          SPDLOG_LOGGER_DEBUG(logger_, "revoke fee={}, qty={} ({}), recv addr: {}"

--- a/BlockSettleUILib/TransactionsWidget.cpp
+++ b/BlockSettleUILib/TransactionsWidget.cpp
@@ -746,7 +746,7 @@ void TransactionsWidget::onTXSigned(unsigned int id, BinaryData signedTX
       if (!armory_->pushZC(signedTX)) {
          BSMessageBox(BSMessageBox::critical, tr("Revoke Transaction")
             , tr("Failed to send revoke transaction")
-            , tr("armory connection unavailable"), this).exec();
+            , tr("BlockSettleDB connection unavailable"), this).exec();
       }
    }
 }

--- a/BlockSettleUILib/TransactionsWidget.h
+++ b/BlockSettleUILib/TransactionsWidget.h
@@ -51,9 +51,9 @@ public:
              , const std::shared_ptr<ArmoryConnection> &
              , const std::shared_ptr<bs::UTXOReservationManager> &
              , const std::shared_ptr<WalletSignerContainer> &
+             , const std::shared_ptr<ApplicationSettings>&
              , const std::shared_ptr<spdlog::logger> &);
    void SetTransactionsModel(const std::shared_ptr<TransactionsViewModel> &);
-   void setAppSettings(std::shared_ptr<ApplicationSettings> appSettings);
 
    void shortcutActivated(ShortcutType s) override;
 

--- a/BlockSettleUILib/UiUtils.cpp
+++ b/BlockSettleUILib/UiUtils.cpp
@@ -153,7 +153,7 @@ bs::hd::Purpose getHwWalletPurpose(WalletsTypes hwType)
 
 }
 
-int UiUtils::selectWalletInCombobox(QComboBox* comboBox, const std::string& walletId)
+int UiUtils::selectWalletInCombobox(QComboBox* comboBox, const std::string& walletId, WalletsTypes type /* = WalletsTypes::None */)
 {
    int walletIndex = -1;
    if (comboBox->count() == 0) {
@@ -162,6 +162,15 @@ int UiUtils::selectWalletInCombobox(QComboBox* comboBox, const std::string& wall
 
    for (int i=0; i<comboBox->count(); ++i) {
       if (comboBox->itemData(i, WalletIdRole).toString().toStdString() == walletId) {
+         if (type != WalletsTypes::None) {
+            auto walletType =
+               static_cast<UiUtils::WalletsTypes>(comboBox->itemData(i, WalletType).toInt());
+
+            if (type != walletType) {
+               continue;
+            }
+         }
+
          walletIndex = i;
          break;
       }

--- a/BlockSettleUILib/UiUtils.h
+++ b/BlockSettleUILib/UiUtils.h
@@ -140,7 +140,7 @@ namespace UiUtils
    void fillRecvAddressesComboBoxHDWallet(QComboBox* comboBox
       , const std::shared_ptr<bs::sync::hd::Wallet>& targetHDWallet, bool showRegularWalletsOnly);
 
-   int selectWalletInCombobox(QComboBox* comboBox, const std::string& walletId);
+   int selectWalletInCombobox(QComboBox* comboBox, const std::string& walletId, WalletsTypes type = WalletsTypes::None);
    std::string getSelectedWalletId(QComboBox* comboBox);
    WalletsTypes getSelectedWalletType(QComboBox* comboBox);
    bs::hd::Purpose getSelectedHwPurpose(QComboBox* comboBox);


### PR DESCRIPTION
Issues:
1. http://185.213.153.35:8081/browse/BST-2683 - AQ button update
2. http://185.213.153.35:8081/browse/BST-2682 - Update Token Entry input behaviour
3. http://185.213.153.35:8081/browse/BST-2680 - regression hs wallets separation, add possibility to receive money on correct wallet & filter addresses
4. http://185.213.153.35:8081/browse/BST-2679 - change Armory UI labels to Blocksettle
5. http://185.213.153.35:8081/browse/BST-2677 - add new substate and label while awaiting signed tx from hw device
6. http://185.213.153.35:8081/browse/BST-2657 - add possibility to set expanded tx info from terminal and carry it up to signer(saving it in user settings for terminal app)
7.  http://185.213.153.35:8081/browse/BST-2656 - update copy for cancel action from terminal against ledger device

Depend on: https://github.com/BlockSettle/common/pull/1917