### PR TITLE
Fix upgrade wallet dialog layout and copy for legacy dialog

### DIFF
--- a/BlockSettleUILib/BSMessageBox.cpp
+++ b/BlockSettleUILib/BSMessageBox.cpp
@@ -109,6 +109,7 @@ void BSMessageBox::setCancelVisible(bool visible)
 void BSMessageBox::enableRichText()
 {
    ui_->labelText->setTextFormat(Qt::RichText);
+   adjustSize();
 }
 
 void BSMessageBox::onDetailsPressed()

--- a/BlockSettleUILib/BSTerminalMainWindow.cpp
+++ b/BlockSettleUILib/BSTerminalMainWindow.cpp
@@ -2065,7 +2065,7 @@ void BSTerminalMainWindow::promoteToPrimaryIfNeeded()
       addDeferredDialog([this, wallet] {
          promoteToPrimaryShown_ = true;
          BSMessageBox qry(BSMessageBox::question, tr("Upgrade Wallet"), tr("Enable Trading?")
-            , tr("BlockSettle requires you to hold sub-wallets able to interact with our trading system. Do you wish to create them now?\n\n"
+            , tr("BlockSettle requires you to hold sub-wallets able to interact with our trading system. Do you wish to create them now?<br/><br/>"
                  "For more information regarding our settlement models, please consult our ") +
                   QStringLiteral("<a href=\"%1\"><span style=\"text-decoration: underline; color: %2;\">Trading Procedures</span></a>")
                   .arg(QStringLiteral("http://pubb.blocksettle.com/PDF/BlockSettle%20Trading%20Procedures.pdf"))
@@ -2116,8 +2116,6 @@ void BSTerminalMainWindow::showLegacyWarningIfNeeded()
          , tr("Legacy Address Balances")
          , tr("The BlockSettle Terminal has detected the use of legacy addresses on your hardware wallet.\n\n"
               "The BlockSettle Terminal supports viewing and spending from legacy addresses, but will not support the following actions related to these addresses:\n\n"
-              "- No GUI support for legacy address generation\n"
-              "- No trading using legacy address input\n"
               "- GUI support for legacy address generation\n"
               "- Trading and settlement using legacy inputs\n\n"
               "BlockSettle strongly recommends that you move your legacy address balances to native SegWit addresses.")


### PR DESCRIPTION
Issues:
1. Delete wrong message lines
2. Improve upgrade wallet dialog