### PR TITLE
Fix crash in QSortFilterProxyModel

### DIFF
--- a/BlockSettleUILib/Trading/QuoteRequestsWidget.cpp
+++ b/BlockSettleUILib/Trading/QuoteRequestsWidget.cpp
@@ -467,7 +467,7 @@ QuoteReqSortModel::QuoteReqSortModel(QuoteRequestsModel *model, QObject *parent)
    , showQuoted_(true)
 {
    connect(model_, &QuoteRequestsModel::invalidateFilterModel,
-      this, &QuoteReqSortModel::invalidate);
+      this, &QuoteReqSortModel::invalidateFilter);
 }
 
 bool QuoteReqSortModel::filterAcceptsRow(int row, const QModelIndex &parent) const


### PR DESCRIPTION
Don't know why, but `QSortFilterProxyModel::invalidate` sometimes cause terminal to crash (happens rarely enough). I was able reproduce that adding and removing RFQs programmatically. Using `QSortFilterProxyModel::invalidateFilter` instead seems to works fine.
[asan.txt](https://github.com/BlockSettle/terminal/files/4599699/asan.txt)
