### PR TITLE
Fix transaction list load constant spinning

### DIFF
--- a/BlockSettleUILib/TransactionsViewModel.cpp
+++ b/BlockSettleUILib/TransactionsViewModel.cpp
@@ -839,6 +839,11 @@ void TransactionsViewModel::loadLedgerEntries(bool onNewBlock)
       try {
          int inPageCnt = int(pageCnt.get());
 
+         if (inPageCnt == 0) {
+            SPDLOG_LOGGER_ERROR(logger, "page count is 0");
+            return;
+         }
+
          QMetaObject::invokeMethod(qApp, [thisPtr, inPageCnt] {
             if (thisPtr) {
                emit thisPtr->initProgress(0, int(inPageCnt * 2));


### PR DESCRIPTION
Sometimes LedgerDelegate returns 0 available pages for some reasons