### PR TITLE
Fix release utxo reservation for cc

### DIFF
--- a/BlockSettleUILib/Trading/RFQDealerReply.cpp
+++ b/BlockSettleUILib/Trading/RFQDealerReply.cpp
@@ -703,6 +703,7 @@ void RFQDealerReply::submitReply(const bs::network::QuoteReqNotification &qrn, d
          const auto &spendWallet = isSpendCC ? ccWallet : xbtWallet;
          const auto &recvWallet = isSpendCC ? xbtWallet : ccWallet;
 
+         preparingCCRequest_.insert(replyData->qn.quoteRequestId);
          auto recvAddrCb = [this, replyData, qrn, spendWallet, spendVal, isSpendCC, ccWallet, xbtWallets, price](const bs::Address &addr) {
             replyData->qn.receiptAddress = addr.display();
             replyData->qn.reqAuthKey = qrn.requestorRecvAddress;
@@ -733,6 +734,10 @@ void RFQDealerReply::submitReply(const bs::network::QuoteReqNotification &qrn, d
                            signingContainer_->resolvePublicSpenders(txReq, [replyData, this, price, txReq]
                               (bs::error::ErrorCode result, const Codec_SignerState::SignerState &state)
                            {
+                              if (preparingCCRequest_.count(replyData->qn.quoteRequestId) == 0) {
+                                 return;
+                              }
+
                               if (result == bs::error::ErrorCode::NoError) {
                                  replyData->qn.transactionData = BinaryData::fromString(state.SerializeAsString()).toHexStr();
                                  replyData->utxoRes = utxoReservationManager_->makeNewReservation(txReq.inputs, replyData->qn.quoteRequestId);
@@ -742,6 +747,7 @@ void RFQDealerReply::submitReply(const bs::network::QuoteReqNotification &qrn, d
                                  SPDLOG_LOGGER_ERROR(logger_, "error resolving public spenders: {}"
                                     , bs::error::ErrorCodeToString(result).toStdString());
                               }
+                              preparingCCRequest_.erase(replyData->qn.quoteRequestId);
                            });
                         } catch (const std::exception &e) {
                            SPDLOG_LOGGER_ERROR(logger_, "error creating own unsigned half: {}", e.what());
@@ -1087,6 +1093,11 @@ void RFQDealerReply::onAutoSignStateChanged()
       ui_->comboBoxXbtWallet->setCurrentText(autoSignQuoteProvider_->getAutoSignWalletName());
    }
    ui_->comboBoxXbtWallet->setEnabled(autoSignQuoteProvider_->autoSignState() == bs::error::ErrorCode::AutoSignDisabled);
+}
+
+void bs::ui::RFQDealerReply::onQuoteCanceled(const std::string &quoteId)
+{
+   preparingCCRequest_.erase(quoteId);
 }
 
 void bs::ui::RFQDealerReply::onUTXOReservationChanged(const std::string& walletId)

--- a/BlockSettleUILib/Trading/RFQDealerReply.cpp
+++ b/BlockSettleUILib/Trading/RFQDealerReply.cpp
@@ -1095,7 +1095,7 @@ void RFQDealerReply::onAutoSignStateChanged()
    ui_->comboBoxXbtWallet->setEnabled(autoSignQuoteProvider_->autoSignState() == bs::error::ErrorCode::AutoSignDisabled);
 }
 
-void bs::ui::RFQDealerReply::onQuoteCanceled(const std::string &quoteId)
+void bs::ui::RFQDealerReply::onQuoteCancelled(const std::string &quoteId)
 {
    preparingCCRequest_.erase(quoteId);
 }

--- a/BlockSettleUILib/Trading/RFQDealerReply.h
+++ b/BlockSettleUILib/Trading/RFQDealerReply.h
@@ -130,7 +130,7 @@ namespace bs {
          void onCelerConnected();
          void onCelerDisconnected();
          void onAutoSignStateChanged();
-         void onQuoteCanceled(const std::string &quoteId);
+         void onQuoteCancelled(const std::string &quoteId);
 
       private slots:
          void initUi();

--- a/BlockSettleUILib/Trading/RFQDealerReply.h
+++ b/BlockSettleUILib/Trading/RFQDealerReply.h
@@ -130,6 +130,7 @@ namespace bs {
          void onCelerConnected();
          void onCelerDisconnected();
          void onAutoSignStateChanged();
+         void onQuoteCanceled(const std::string &quoteId);
 
       private slots:
          void initUi();
@@ -198,6 +199,8 @@ namespace bs {
          SubmitQuoteNotifCb submitQuoteNotifCb_;
          ResetCurrentReservationCb resetCurrentReservationCb_;
          GetLastUTXOReplyCb getLastUTXOReplyCb_;
+
+         std::set<std::string> preparingCCRequest_;
 
       private:
          enum class ReplyType

--- a/BlockSettleUILib/Trading/RFQReplyWidget.cpp
+++ b/BlockSettleUILib/Trading/RFQReplyWidget.cpp
@@ -391,6 +391,7 @@ void RFQReplyWidget::onQuoteCancelled(const QString &reqId, bool userCancelled)
 {
    eraseReply(reqId);
    ui_->widgetQuoteRequests->onQuoteReqCancelled(reqId, userCancelled);
+   ui_->pageRFQReply->onQuoteCanceled(reqId.toStdString());
 }
 
 void RFQReplyWidget::onQuoteRejected(const QString &reqId, const QString &reason)

--- a/BlockSettleUILib/Trading/RFQReplyWidget.cpp
+++ b/BlockSettleUILib/Trading/RFQReplyWidget.cpp
@@ -391,7 +391,7 @@ void RFQReplyWidget::onQuoteCancelled(const QString &reqId, bool userCancelled)
 {
    eraseReply(reqId);
    ui_->widgetQuoteRequests->onQuoteReqCancelled(reqId, userCancelled);
-   ui_->pageRFQReply->onQuoteCanceled(reqId.toStdString());
+   ui_->pageRFQReply->onQuoteCancelled(reqId.toStdString());
 }
 
 void RFQReplyWidget::onQuoteRejected(const QString &reqId, const QString &reason)


### PR DESCRIPTION
Issue: cleanup properly UTXO reservation for CC tokens
Repro:
1. Start the AQ script to reply all CC request to trading
2. In other client fast cancel/start new quote request for CC

Notice: after QuoteProvider::onQuoteCancelled sometimes we still send the request from async lambda inside quote CC response in dealer tab, and as result we will reserve CC utxo for the quote which will never be released till the terminal restart.