### PR TITLE
Minor chat fixes

### DIFF
--- a/BlockSettleUILib/ChatUI/ChatWidget.cpp
+++ b/BlockSettleUILib/ChatUI/ChatWidget.cpp
@@ -217,7 +217,7 @@ otc::Peer *ChatWidget::currentPeer() const
    }
 
    const auto clientPartyPtr = partyTreeItem->data().value<Chat::ClientPartyPtr>();
-   if (!clientPartyPtr) {
+   if (!clientPartyPtr || clientPartyPtr->isGlobalStandard()) {
       return nullptr;
    }
 

--- a/BlockSettleUILib/Trading/OtcClient.cpp
+++ b/BlockSettleUILib/Trading/OtcClient.cpp
@@ -258,7 +258,7 @@ Peer *OtcClient::response(const std::string &contactId)
 Peer *OtcClient::peer(const std::string &contactId, PeerType type)
 {
    if (contactId.size() != kContactIdSize) {
-      SPDLOG_LOGGER_DEBUG(logger_, "unexpected contact requested: {}");
+      SPDLOG_LOGGER_DEBUG(logger_, "unexpected contact requested: {}", contactId);
    }
 
    switch (type)


### PR DESCRIPTION
- Remove contact's public keys change prompt when only timestamp changed
- Do not call OtcClient::peer for `Global` contactId