### PR TITLE
Ability to decode signer state in explorer

### DIFF
--- a/BlockSettleUILib/ExplorerWidget.cpp
+++ b/BlockSettleUILib/ExplorerWidget.cpp
@@ -143,7 +143,7 @@ void ExplorerWidget::onSearchStarted(bool saveToHistory)
          pushTransactionHistory(userStr);
       }
    }
-   else if ((userStr.length() == 64) &&
+   else if ((userStr.length() >= 64) &&
            userStr.toStdString().find_first_not_of("0123456789abcdefABCDEF", 2) == std::string::npos) {
       // String is a valid 32 byte hex string, so we may proceed.
       if (saveToHistory) {
@@ -156,7 +156,7 @@ void ExplorerWidget::onSearchStarted(bool saveToHistory)
    else {
       // This isn't a valid address or 32 byte hex string.
       QToolTip::showText(ui_->searchBox->mapToGlobal(QPoint(0, 7))
-         , tr("This is not a valid address or transaction ID."), ui_->searchBox);
+         , tr("This is not a valid address or transaction ID"), ui_->searchBox);
    }
 
    ui_->btnBack->setEnabled(canGoBack());
@@ -242,7 +242,7 @@ bool ExplorerWidget::canGoForward() const
    return searchHistoryPosition_ < static_cast<int>(searchHistory_.size()) - 1;
 }
 
-void ExplorerWidget::setTransaction(QString txId)
+void ExplorerWidget::setTransaction(const QString &txId)
 {
    ui_->stackedWidget->setCurrentIndex(TxPage);
    // Pass the Tx hash to the Tx widget and populate the fields.

--- a/BlockSettleUILib/ExplorerWidget.h
+++ b/BlockSettleUILib/ExplorerWidget.h
@@ -63,7 +63,7 @@ protected slots:
 private:
    bool canGoBack() const;
    bool canGoForward() const;
-   void setTransaction(QString txId);
+   void setTransaction(const QString &txId);
    void pushTransactionHistory(QString itemId);
    void truncateSearchHistory(int position = -1);
    void clearSearchHistory();

--- a/BlockSettleUILib/TransactionDetailsWidget.h
+++ b/BlockSettleUILib/TransactionDetailsWidget.h
@@ -102,14 +102,13 @@ protected:
    void loadTreeOut(CustomTreeWidget *tree);
 
 private:
-   void getHeaderData(const BinaryData& inHeader);
    void loadInputs();
    void setTxGUIValues();
    void clear();
    void updateCCInputs();
    void checkTxForCC(const Tx &, QTreeWidget *);
 
-   void processTxData(Tx tx);
+   void processTxData(const Tx &tx);
 
    void addItem(QTreeWidget *tree, const QString &address, const uint64_t amount
       , const QString &wallet, const BinaryData &txHash, const int txIndex = -1);


### PR DESCRIPTION
This is sometimes required to debug weird issues with OTC settlement in PB - signer state needs to be in hex format (as it's transmitted from the terminal to PB).