### PR TITLE
Allow to import several trezor hw devices

### DIFF
--- a/BlockSettleHW/hwdeviceinterface.h
+++ b/BlockSettleHW/hwdeviceinterface.h
@@ -44,6 +44,7 @@ public:
    // operation
    virtual void getPublicKey(AsyncCallBackCall&& cb = nullptr) = 0;
    virtual void signTX(const bs::core::wallet::TXSignRequest& reqTX, AsyncCallBackCall&& cb = nullptr) = 0;
+   virtual void retrieveXPubRoot(AsyncCallBack&& cb) = 0;
 
    // Management
    virtual void setMatrixPin(const std::string& pin) {};
@@ -52,6 +53,11 @@ public:
    // State
    virtual bool isBlocked() = 0;
    virtual QString lastError() { return {}; };
+
+   // xpub root
+   bool inited() {
+      return !xpubRoot_.empty();
+   }
 
 signals:
    // operation result informing
@@ -65,6 +71,9 @@ signals:
    void requestHWPass(bool allowedOnDevice);
    void cancelledOnDevice();
    void invalidPin();
+
+protected:
+   std::string xpubRoot_;
 };
 
 #endif // HWDEVICEABSTRACT_H

--- a/BlockSettleHW/hwdevicemanager.h
+++ b/BlockSettleHW/hwdevicemanager.h
@@ -64,8 +64,8 @@ public:
 signals:
    void devicesChanged();
    void publicKeyReady(QVariant walletInfo);
-   void requestPinMatrix();
-   void requestHWPass(bool allowedOnDevice);
+   void requestPinMatrix(int deviceIndex);
+   void requestHWPass(int deviceIndex, bool allowedOnDevice);
 
    void deviceNotFound(QString deviceId);
    void deviceReady(QString deviceId);
@@ -77,10 +77,14 @@ signals:
    void cancelledOnDevice();
    void invalidPin();
 
+protected slots:
+   void onRequestPinMatrix();
+   void onRequestHWPass(bool allowedOnDevice);
+
 private:
    void setScanningFlag(bool isScanning);
    void releaseConnection(AsyncCallBack&& cb = nullptr);
-   void scanningDone();
+   void scanningDone(bool initDevices = true);
 
    QPointer<HwDeviceInterface> getDevice(DeviceKey key);
 

--- a/BlockSettleHW/hwdevicemodel.cpp
+++ b/BlockSettleHW/hwdevicemodel.cpp
@@ -90,6 +90,17 @@ DeviceKey HwDeviceModel::getDevice(int index)
    return devices_[index];
 }
 
+int HwDeviceModel::getDeviceIndex(DeviceKey key)
+{
+   for (int i = 0; i < devices_.size(); ++i) {
+      if (devices_[i].deviceId_ == key.deviceId_) {
+         return i;
+      }
+   }
+
+   return -1;
+}
+
 QHash<int, QByteArray> HwDeviceModel::roleNames() const
 {
    return {

--- a/BlockSettleHW/hwdevicemodel.h
+++ b/BlockSettleHW/hwdevicemodel.h
@@ -39,6 +39,7 @@ public:
 
    void resetModel(QVector<DeviceKey>&& deviceKey);
    DeviceKey getDevice(int index);
+   int getDeviceIndex(DeviceKey key);
 
 private:
    QVector<DeviceKey> devices_;

--- a/BlockSettleHW/ledger/ledgerDevice.h
+++ b/BlockSettleHW/ledger/ledgerDevice.h
@@ -53,10 +53,7 @@ public:
    // operation
    void getPublicKey(AsyncCallBackCall&& cb = nullptr) override;
    void signTX(const bs::core::wallet::TXSignRequest &reqTX, AsyncCallBackCall&& cb = nullptr) override;
-
-   bool inited() {
-      return !xpubRoot_.empty();
-   }
+   void retrieveXPubRoot(AsyncCallBack&& cb) override {} // no special rule for ledger device
 
    bool isBlocked() override {
       return isBlocked_;
@@ -77,8 +74,6 @@ private:
    QPointer<LedgerCommandThread> commandThread_;
    bool isBlocked_{};
    QString lastError_{};
-   
-   std::string xpubRoot_;
 };
 
 class LedgerCommandThread : public QThread

--- a/BlockSettleHW/trezor/trezorClient.cpp
+++ b/BlockSettleHW/trezor/trezorClient.cpp
@@ -158,18 +158,7 @@ QVector<DeviceKey> TrezorClient::deviceKeys() const
    if (!trezorDevice_) {
       return {};
    }
-
    auto key = trezorDevice_->key();
-   auto wallets = walletManager_->getHwWallets(bs::wallet::HardwareEncKey::WalletType::Trezor
-      , key.deviceId_.toStdString());
-
-   if (!wallets.empty()) {
-      // Some hw devices do not have proper deviceid
-      // but trezor do have, and we expected it unique
-      assert(wallets.size() == 1);
-      key.walletId_ = QString::fromStdString(wallets[0]);
-   }
-
    return { key };
 }
 

--- a/BlockSettleHW/trezor/trezorDevice.cpp
+++ b/BlockSettleHW/trezor/trezorDevice.cpp
@@ -99,12 +99,32 @@ TrezorDevice::~TrezorDevice() = default;
 
 DeviceKey TrezorDevice::key() const
 {
+   QString walletId;
+   QString status;
+   if (!xpubRoot_.empty()) {
+      auto expectedWalletId = bs::core::wallet::computeID(
+         BinaryData::fromString(xpubRoot_)).toBinStr();
+
+      auto importedWallets = walletManager_->getHwWallets(
+         bs::wallet::HardwareEncKey::WalletType::Trezor, features_.device_id());
+
+      for (const auto imported : importedWallets) {
+         if (expectedWalletId == imported) {
+            walletId = QString::fromStdString(expectedWalletId);
+            break;
+         }
+      }
+   }
+   else {
+      status = tr("Not initialized");
+   }
+
    return {
       QString::fromStdString(features_.label())
       , QString::fromStdString(features_.device_id())
       , QString::fromStdString(features_.vendor())
-      , {}
-      , {}
+      , walletId
+      , status
       , type()
    };
 }
@@ -120,10 +140,7 @@ void TrezorDevice::init(AsyncCallBack&& cb)
    management::Initialize message;
    message.set_session_id(client_->getSessionId());
 
-   if (cb) {
-      setCallbackNoData(MessageType_Features, std::move(cb));
-   }
-
+   setCallbackNoData(MessageType_Features, std::move(cb));
    makeCall(message);
 }
 
@@ -135,6 +152,7 @@ void TrezorDevice::getPublicKey(AsyncCallBackCall&& cb)
    awaitingWalletInfo_.info_.label = features_.label();
    awaitingWalletInfo_.info_.deviceId = features_.device_id();
    awaitingWalletInfo_.info_.vendor = features_.vendor();
+   awaitingWalletInfo_.info_.xpubRoot = xpubRoot_;
 
    awaitingWalletInfo_.isFirmwareSupported_ = isFirmwareSupported();
    if (!awaitingWalletInfo_.isFirmwareSupported_) {
@@ -190,35 +208,19 @@ void TrezorDevice::getPublicKey(AsyncCallBackCall&& cb)
       makeCall(message);
    };
 
-   AsyncCallBackCall cbRoot = [this, cbNative = std::move(cbNative)](QVariant &&data) mutable {
-      awaitingWalletInfo_.info_.xpubRoot = data.toByteArray().toStdString();
 
-      connectionManager_->GetLogger()->debug("[TrezorDevice] init - start retrieving native segwit public key from device "
-         + features_.label());
-      bitcoin::GetPublicKey message;
-      for (const uint32_t add : getDerivationPath(testNet_, bs::hd::Purpose::Native)) {
-         message.add_address_n(add);
-      }
-
-      if (testNet_) {
-         message.set_coin_name(tesNetCoin);
-      }
-
-      setDataCallback(MessageType_PublicKey, std::move(cbNative));
-      makeCall(message);
-   };
-
-   // Fetching walletId
-   connectionManager_->GetLogger()->debug("[TrezorDevice] init - start retrieving root public key from device "
+   connectionManager_->GetLogger()->debug("[TrezorDevice] init - start retrieving native segwit public key from device "
       + features_.label());
    bitcoin::GetPublicKey message;
-   message.add_address_n(bs::hd::hardFlag);
+   for (const uint32_t add : getDerivationPath(testNet_, bs::hd::Purpose::Native)) {
+      message.add_address_n(add);
+   }
+
    if (testNet_) {
       message.set_coin_name(tesNetCoin);
    }
 
-   // Fetching nested segwit
-   setDataCallback(MessageType_PublicKey, std::move(cbRoot));
+   setDataCallback(MessageType_PublicKey, std::move(cbNative));
    makeCall(message);
 }
 
@@ -282,6 +284,32 @@ void TrezorDevice::signTX(const bs::core::wallet::TXSignRequest &reqTX, AsyncCal
    }
 
    awaitingTransaction_ = {};
+   makeCall(message);
+}
+
+void TrezorDevice::retrieveXPubRoot(AsyncCallBack&& cb)
+{
+   // Fetching walletId
+   connectionManager_->GetLogger()->debug("[TrezorDevice] init - start retrieving root public key from device "
+      + features_.label());
+   bitcoin::GetPublicKey message;
+   message.add_address_n(bs::hd::hardFlag);
+   if (testNet_) {
+      message.set_coin_name(tesNetCoin);
+   }
+
+   auto saveXpubRoot = [caller = QPointer<TrezorDevice>(this), cb = std::move(cb)](QVariant&& data) {
+      if (!caller) {
+         return;
+      }
+
+      caller->xpubRoot_ = data.toByteArray().toStdString();
+      if (cb) {
+         cb();
+      }
+   };
+
+   setDataCallback(MessageType_PublicKey, std::move(saveXpubRoot));
    makeCall(message);
 }
 

--- a/BlockSettleHW/trezor/trezorDevice.h
+++ b/BlockSettleHW/trezor/trezorDevice.h
@@ -62,6 +62,7 @@ public:
    // operation
    void getPublicKey(AsyncCallBackCall&& cb = nullptr) override;
    void signTX(const bs::core::wallet::TXSignRequest& reqTX, AsyncCallBackCall&& cb = nullptr) override;
+   void retrieveXPubRoot(AsyncCallBack&& cb) override;
 
    // Management
    void setMatrixPin(const std::string& pin) override;

--- a/BlockSettleSigner/qml/BsDialogs/TxSignDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/TxSignDialog.qml
@@ -88,9 +88,9 @@ BSWalletHandlerDialog {
 
     Connections {
         target: hwDeviceManager
-        onRequestPinMatrix: JsHelper.showHwPinMatrix(0);
+        onRequestPinMatrix: JsHelper.showHwPinMatrix(deviceIndex);
         onDeviceReady: hwDeviceManager.signTX(passwordDialogData.TxRequest);
-        onRequestHWPass: JsHelper.showHwPassphrase(0, allowedOnDevice);
+        onRequestHWPass: JsHelper.showHwPassphrase(deviceIndex, allowedOnDevice);
         onDeviceNotFound: {
             hwDeviceStatus = "Searching for device"
             let lastDeviceError = hwDeviceManager.lastDeviceError(0);

--- a/BlockSettleSigner/qml/BsDialogs/TxSignSettlementBaseDialog.qml
+++ b/BlockSettleSigner/qml/BsDialogs/TxSignSettlementBaseDialog.qml
@@ -162,9 +162,9 @@ CustomTitleDialogWindowWithExpander {
 
     Connections {
         target: hwDeviceManager
-        onRequestPinMatrix: JsHelper.showHwPinMatrix(0);
+        onRequestPinMatrix: JsHelper.showHwPinMatrix(deviceIndex);
         onDeviceReady: hwDeviceManager.signTX(passwordDialogData.TxRequest);
-        onRequestHWPass: JsHelper.showHwPassphrase(0, allowedOnDevice);
+        onRequestHWPass: JsHelper.showHwPassphrase(deviceIndex, allowedOnDevice);
         onDeviceNotFound: {
             hwDeviceStatus = qsTr("Searching for device")
             let lastDeviceError = hwDeviceManager.lastDeviceError(0);

--- a/BlockSettleSigner/qml/BsHw/HwAvailableDevices.qml
+++ b/BlockSettleSigner/qml/BsHw/HwAvailableDevices.qml
@@ -38,8 +38,8 @@ Item {
             hwWalletInfo = walletInfo;
             root.pubKeyReady()
         }
-        onRequestPinMatrix: JsHelper.showHwPinMatrix(hwList.deviceIndex);
-        onRequestHWPass: JsHelper.showHwPassphrase(hwList.deviceIndex, allowedOnDevice);
+        onRequestPinMatrix: JsHelper.showHwPinMatrix(deviceIndex);
+        onRequestHWPass: JsHelper.showHwPassphrase(deviceIndex, allowedOnDevice);
         onOperationFailed: {
             hwWalletInfo = {};
             isImporting = false;
@@ -98,7 +98,7 @@ Item {
 
                     leftPadding: 10
                     text: model.label + "(" + model.vendor + ")"
-                    enabled: model.pairedWallet.length === 0
+                    enabled: model.pairedWallet.length === 0 && model.status.length === 0
                     color: textColor
                     font.pixelSize: 12
                     horizontalAlignment: Text.AlignLeft
@@ -111,8 +111,13 @@ Item {
                     height: parent.height
 
                     rightPadding: 10
-                    text: model.pairedWallet.length ? "Imported(" + model.pairedWallet + ")" : "New Device"
-                    enabled: model.pairedWallet.length === 0
+                    text: if (model.status.length)
+                              status;
+                          else if (model.pairedWallet.length)
+                              "Imported(" + model.pairedWallet + ")";
+                          else
+                              "New Device";
+                    enabled: model.pairedWallet.length === 0 && model.status.length === 0
                     color: textColor
                     font.pixelSize: 12
                     horizontalAlignment: Text.AlignRight
@@ -135,11 +140,18 @@ Item {
 
             Connections {
                 target: hwList
-                onCurrentIndexChanged: {
-                    if (hwList.currentIndex === index) {
-                        hwList.deviceIndex = model.pairedWallet.length === 0 ? index : -1
-                        root.readyForImport = (hwList.deviceIndex !== -1);
-                    }
+                onCurrentIndexChanged: checkReadyForImport()
+            }
+
+            Connections {
+                target: hwDeviceManager.devices
+                onModelReset: checkReadyForImport()
+            }
+
+            function checkReadyForImport() {
+                if (hwList.currentIndex === index) {
+                    hwList.deviceIndex = model.pairedWallet.length === 0 && model.status.length === 0 ? index : -1
+                    root.readyForImport = (hwList.deviceIndex !== -1);
                 }
             }
         }
@@ -150,4 +162,6 @@ Item {
         }
 
     }
+
+
 }


### PR DESCRIPTION
Issues: we should allow to import several hw wallet from the same devices, which are could be distinguish but encryption password.

Repro:
1. Add trezor wallet which is encrypted by passphrase
2. Try to add  other hw wallet from this device.

Result: we will not gibe user possibility to do that
Expected result: we should distinguish which wallet exactly user  want to import, and only disallow it, if there already such wallet have been imported