### PR TITLE
Fix crash when trying to get primary wallet which is not inited

### DIFF
--- a/BlockSettleUILib/Trading/RFQTicketXBT.cpp
+++ b/BlockSettleUILib/Trading/RFQTicketXBT.cpp
@@ -1334,7 +1334,7 @@ std::shared_ptr<bs::sync::hd::Wallet> RFQTicketXBT::getRecvXbtWallet() const
    }
    auto wallet = walletsManager_->getHDWalletById(ui_->comboBoxXBTWalletsRecv->
       currentData(UiUtils::WalletIdRole).toString().toStdString());
-   if (!wallet) {
+   if (!wallet && walletsManager_->getDefaultWallet()) {
       wallet = walletsManager_->getHDRootForLeaf(walletsManager_->getDefaultWallet()->walletId());
    }
    return wallet;


### PR DESCRIPTION
Issue: crash when deleting wallet and there is no primary wallet

Repro:
1. Start terminal with no primary wallet
2. Add hw wallet(or make sure there is no one primary) if there none or add new one
3. Delete hw - crash, this is only possible when you do not have primary wallet