### PR TITLE
Replace MDInfo from common

### DIFF
--- a/BlockSettleUILib/Trading/RFQDealerReply.cpp
+++ b/BlockSettleUILib/Trading/RFQDealerReply.cpp
@@ -960,28 +960,15 @@ void RFQDealerReply::onTransactionDataChanged()
 
 void RFQDealerReply::onMDUpdate(bs::network::Asset::Type, const QString &security, bs::network::MDFields mdFields)
 {
-   const double bid = bs::network::MDField::get(mdFields, bs::network::MDField::PriceBid).value;
-   const double ask = bs::network::MDField::get(mdFields, bs::network::MDField::PriceOffer).value;
-   const double last = bs::network::MDField::get(mdFields, bs::network::MDField::PriceLast).value;
-
    auto &mdInfo = mdInfo_[security.toStdString()];
-   if (bid > 0) {
-      mdInfo.bidPrice = bid;
-   }
-   if (ask > 0) {
-      mdInfo.askPrice = ask;
-   }
-   if (last > 0) {
-      mdInfo.lastPrice = last;
-   }
-
+   mdInfo.merge(bs::network::MDField::get(mdFields));
    if (autoUpdatePrices_ && (currentQRN_.security == security.toStdString())
       && (bestQPrices_.find(currentQRN_.quoteRequestId) == bestQPrices_.end())) {
-      if (!qFuzzyIsNull(bid)) {
-         ui_->spinBoxBidPx->setValue(bid);
+      if (!qFuzzyIsNull(mdInfo.bidPrice)) {
+         ui_->spinBoxBidPx->setValue(mdInfo.bidPrice);
       }
-      if (!qFuzzyIsNull(ask)) {
-         ui_->spinBoxOfferPx->setValue(ask);
+      if (!qFuzzyIsNull(mdInfo.askPrice)) {
+         ui_->spinBoxOfferPx->setValue(mdInfo.askPrice);
       }
    }
 }

--- a/BlockSettleUILib/Trading/RFQDealerReply.h
+++ b/BlockSettleUILib/Trading/RFQDealerReply.h
@@ -26,6 +26,7 @@
 #include "QWalletInfo.h"
 #include "HDPath.h"
 #include "UtxoReservationToken.h"
+#include "CommonTypes.h"
 
 namespace Ui {
     class RFQDealerReply;
@@ -186,12 +187,7 @@ namespace bs {
          std::unordered_map<std::string, double>   bestQPrices_;
          QFont invalidBalanceFont_;
 
-         struct MDInfo {
-            double   bidPrice{};
-            double   askPrice{};
-            double   lastPrice{};
-         };
-         std::unordered_map<std::string, MDInfo>  mdInfo_;
+         std::unordered_map<std::string, bs::network::MDInfo>  mdInfo_;
 
          std::vector<UTXO> selectedXbtInputs_;
          bs::UtxoReservationToken selectedXbtRes_;

--- a/BlockSettleUILib/Trading/RFQRequestWidget.cpp
+++ b/BlockSettleUILib/Trading/RFQRequestWidget.cpp
@@ -30,6 +30,7 @@
 #include "Wallets/SyncHDWallet.h"
 #include "UserScriptRunner.h"
 #include "UtxoReservationManager.h"
+#include "MDCallbacksQt.h"
 
 #include "bs_proxy_terminal_pb.pb.h"
 
@@ -201,6 +202,8 @@ void RFQRequestWidget::initWidgets(const std::shared_ptr<MarketDataProvider>& md
    appSettings_ = appSettings;
    ui_->widgetMarketData->init(appSettings, ApplicationSettings::Filter_MD_RFQ
       , mdProvider, mdCallbacks);
+
+   connect(mdCallbacks.get(), &MDCallbacksQt::MDUpdate, ui_->pageRFQTicket, &RFQTicketXBT::onMDUpdate);
 }
 
 void RFQRequestWidget::init(const std::shared_ptr<spdlog::logger> &logger

--- a/BlockSettleUILib/Trading/RFQTicketXBT.cpp
+++ b/BlockSettleUILib/Trading/RFQTicketXBT.cpp
@@ -683,7 +683,7 @@ bool RFQTicketXBT::checkAuthAddr(double qty) const
          return tradeSettings->xbtTier1Limit > bs::XBTAmount(qty).GetValue();
       }
       else {
-         const double indPrice = getInidcativePrice();
+         const double indPrice = getIndicativePrice();
          bs::XBTAmount price(indPrice * (1 + (tradeSettings->xbtPriceBand / 100)));
          return price > bs::XBTAmount(qty);
       }
@@ -1257,7 +1257,7 @@ void RFQTicketXBT::updateIndicativePrice()
    }
 }
 
-double RFQTicketXBT::getInidcativePrice() const
+double RFQTicketXBT::getIndicativePrice() const
 {
    const auto &mdIt = mdInfo_.find(ui_->labelSecurityId->text().toStdString());
    if (mdIt == mdInfo_.end()) {
@@ -1268,8 +1268,11 @@ double RFQTicketXBT::getInidcativePrice() const
    if (selectedSide == bs::network::Side::Undefined) {
       return .0;
    }
-   int numCcySelected = ui_->pushButtonNumCcy->isChecked();
-   bool isSell = numCcySelected ^ (selectedSide == bs::network::Side::Buy);
+   bool numCcySelected = ui_->pushButtonNumCcy->isChecked();
+   bool isSell = selectedSide == bs::network::Side::Buy
+      ? !numCcySelected
+      : numCcySelected;
+
    if (isSell) {
       return mdIt->second.bidPrice;
    }

--- a/BlockSettleUILib/Trading/RFQTicketXBT.cpp
+++ b/BlockSettleUILib/Trading/RFQTicketXBT.cpp
@@ -683,10 +683,7 @@ bool RFQTicketXBT::checkAuthAddr(double qty) const
          return tradeSettings->xbtTier1Limit > bs::XBTAmount(qty).GetValue();
       }
       else {
-         QString indicativePrice = ui_->labelIndicativePrice->text();
-         QRegExp space(QLatin1String("\\s"));
-         indicativePrice.remove(space);
-         const double indPrice = indicativePrice.toDouble();
+         const double indPrice = getInidcativePrice();
          bs::XBTAmount price(indPrice * (1 + (tradeSettings->xbtPriceBand / 100)));
          return price > bs::XBTAmount(qty);
       }
@@ -1015,6 +1012,12 @@ void RFQTicketXBT::onCancelRFQ(const std::string &id)
    pendingRFQs_.erase(itRFQ);
 }
 
+void RFQTicketXBT::onMDUpdate(bs::network::Asset::Type, const QString &security, bs::network::MDFields mdFields)
+{
+   auto &mdInfo = mdInfo_[security.toStdString()];
+   mdInfo.merge(bs::network::MDField::get(mdFields));
+}
+
 QPushButton* RFQTicketXBT::submitButton() const
 {
    return ui_->pushButtonSubmit;
@@ -1251,6 +1254,27 @@ void RFQTicketXBT::updateIndicativePrice()
       }
    } else {
       ui_->labelIndicativePrice->setText(kEmptyInformationalLabelText);
+   }
+}
+
+double RFQTicketXBT::getInidcativePrice() const
+{
+   const auto &mdIt = mdInfo_.find(ui_->labelSecurityId->text().toStdString());
+   if (mdIt == mdInfo_.end()) {
+      return false;
+   }
+
+   auto selectedSide = getSelectedSide();
+   if (selectedSide == bs::network::Side::Undefined) {
+      return .0;
+   }
+   int numCcySelected = ui_->pushButtonNumCcy->isChecked();
+   bool isSell = numCcySelected ^ (selectedSide == bs::network::Side::Buy);
+   if (isSell) {
+      return mdIt->second.bidPrice;
+   }
+   else {
+      return mdIt->second.askPrice;
    }
 }
 

--- a/BlockSettleUILib/Trading/RFQTicketXBT.h
+++ b/BlockSettleUILib/Trading/RFQTicketXBT.h
@@ -208,7 +208,7 @@ private:
 
    void SetCurrentIndicativePrices(const QString& bidPrice, const QString& offerPrice);
    void updateIndicativePrice();
-   double getInidcativePrice() const;
+   double getIndicativePrice() const;
 
    void productSelectionChanged();
 

--- a/BlockSettleUILib/Trading/RFQTicketXBT.h
+++ b/BlockSettleUILib/Trading/RFQTicketXBT.h
@@ -117,6 +117,8 @@ public slots:
    void onSendRFQ(const std::string &id, const QString &symbol, double amount, bool buy);
    void onCancelRFQ(const std::string &id);
 
+   void onMDUpdate(bs::network::Asset::Type, const QString &security, bs::network::MDFields);
+
 private slots:
    void updateBalances();
    void onSignerReady();
@@ -206,6 +208,7 @@ private:
 
    void SetCurrentIndicativePrices(const QString& bidPrice, const QString& offerPrice);
    void updateIndicativePrice();
+   double getInidcativePrice() const;
 
    void productSelectionChanged();
 
@@ -263,6 +266,8 @@ private:
 
    bool  autoRFQenabled_{ false };
    std::vector<std::string>   deferredRFQs_;
+
+   std::unordered_map<std::string, bs::network::MDInfo>  mdInfo_;
 };
 
 #endif // __RFQ_TICKET_XBT_H__

--- a/BlockSettleUILib/UserScript.cpp
+++ b/BlockSettleUILib/UserScript.cpp
@@ -364,37 +364,23 @@ void RFQScript::onMDUpdate(bs::network::Asset::Type, const QString &security,
    if (!started_) {
       return;
    }
-   const double bid = bs::network::MDField::get(mdFields, bs::network::MDField::PriceBid).value;
-   const double ask = bs::network::MDField::get(mdFields, bs::network::MDField::PriceOffer).value;
-   const double last = bs::network::MDField::get(mdFields, bs::network::MDField::PriceLast).value;
 
    auto &mdInfo = mdInfo_[security.toStdString()];
-   if (bid > 0) {
-      mdInfo.bidPrice = bid;
-      emit indicBidChanged(security, bid);
-   }
-   if (ask > 0) {
-      mdInfo.askPrice = ask;
-      emit indicAskChanged(security, ask);
-   }
-   if (last > 0) {
-      mdInfo.lastPrice = last;
-      emit lastPriceChanged(security, last);
-   }
+   mdInfo.merge(bs::network::MDField::get(mdFields));
 
    for (const auto &rfq : activeRFQs_) {
       const auto &sec = rfq.second->security();
       if (sec.isEmpty() || (security != sec)) {
          continue;
       }
-      if (bid > 0) {
-         rfq.second->setIndicBid(bid);
+      if (mdInfo.bidPrice > 0) {
+         rfq.second->setIndicBid(mdInfo.bidPrice);
       }
-      if (ask > 0) {
-         rfq.second->setIndicAsk(ask);
+      if (mdInfo.askPrice > 0) {
+         rfq.second->setIndicAsk(mdInfo.askPrice);
       }
-      if (last > 0) {
-         rfq.second->setLastPrice(last);
+      if (mdInfo.lastPrice > 0) {
+         rfq.second->setLastPrice(mdInfo.lastPrice);
       }
    }
 }

--- a/BlockSettleUILib/UserScript.h
+++ b/BlockSettleUILib/UserScript.h
@@ -451,12 +451,7 @@ private:
    std::shared_ptr<spdlog::logger> logger_;
    std::unordered_map<std::string, SubmitRFQ *> activeRFQs_;
 
-   struct MDInfo {
-      double   bidPrice;
-      double   askPrice;
-      double   lastPrice;
-   };
-   std::unordered_map<std::string, MDInfo>  mdInfo_;
+   std::unordered_map<std::string, bs::network::MDInfo>  mdInfo_;
 };
 
 

--- a/BlockSettleUILib/UserScriptRunner.cpp
+++ b/BlockSettleUILib/UserScriptRunner.cpp
@@ -244,20 +244,8 @@ void AQScriptHandler::clear()
 void AQScriptHandler::onMDUpdate(bs::network::Asset::Type, const QString &security,
    bs::network::MDFields mdFields)
 {
-   const double bid = bs::network::MDField::get(mdFields, bs::network::MDField::PriceBid).value;
-   const double ask = bs::network::MDField::get(mdFields, bs::network::MDField::PriceOffer).value;
-   const double last = bs::network::MDField::get(mdFields, bs::network::MDField::PriceLast).value;
-
    auto &mdInfo = mdInfo_[security.toStdString()];
-   if (bid > 0) {
-      mdInfo.bidPrice = bid;
-   }
-   if (ask > 0) {
-      mdInfo.askPrice = ask;
-   }
-   if (last > 0) {
-      mdInfo.lastPrice = last;
-   }
+   mdInfo.merge(bs::network::MDField::get(mdFields));
 
    for (auto aqObj : aqObjs_) {
       QString sec = aqObj.second->property("security").toString();
@@ -266,14 +254,14 @@ void AQScriptHandler::onMDUpdate(bs::network::Asset::Type, const QString &securi
       }
 
       auto *reqReply = qobject_cast<BSQuoteReqReply *>(aqObj.second);
-      if (bid > 0) {
-         reqReply->setIndicBid(bid);
+      if (mdInfo.bidPrice > 0) {
+         reqReply->setIndicBid(mdInfo.bidPrice);
       }
-      if (ask > 0) {
-         reqReply->setIndicAsk(ask);
+      if (mdInfo.askPrice > 0) {
+         reqReply->setIndicAsk(mdInfo.askPrice);
       }
-      if (last > 0) {
-         reqReply->setLastPrice(last);
+      if (mdInfo.lastPrice > 0) {
+         reqReply->setLastPrice(mdInfo.lastPrice);
       }
       reqReply->start();
    }

--- a/BlockSettleUILib/UserScriptRunner.h
+++ b/BlockSettleUILib/UserScriptRunner.h
@@ -22,6 +22,7 @@
 
 #include "UserScript.h"
 #include "QuoteProvider.h"
+#include "CommonTypes.h"
 
 QT_BEGIN_NAMESPACE
 class QThread;
@@ -126,12 +127,7 @@ private:
    std::unordered_map<std::string, bs::network::QuoteReqNotification> aqQuoteReqs_;
    std::unordered_map<std::string, double>   bestQPrices_;
 
-   struct MDInfo {
-      double   bidPrice;
-      double   askPrice;
-      double   lastPrice;
-   };
-   std::unordered_map<std::string, MDInfo>  mdInfo_;
+   std::unordered_map<std::string, bs::network::MDInfo>  mdInfo_;
 
    bool aqEnabled_;
    QTimer *aqTimer_;


### PR DESCRIPTION
Issue: http://185.213.153.35:8081/browse/BST-2772
Refactoring:
1. Replace MDInfo classes with one from common
2. On RFQ ticket creation make possible to compare indicative price based on double value.

Based on https://github.com/BlockSettle/common/pull/2012