### PR TITLE
Fix signed payin hash validations

### DIFF
--- a/BlockSettleUILib/Trading/DealerXBTSettlementContainer.h
+++ b/BlockSettleUILib/Trading/DealerXBTSettlementContainer.h
@@ -129,7 +129,7 @@ private:
    unsigned int   payinSignId_ = 0;
    unsigned int   payoutSignId_ = 0;
 
-   BinaryData        usedPayinHash_;
+   BinaryData        expectedPayinHash_;
 
    std::vector<UTXO> utxosPayinFixed_;
    bs::Address       recvAddr_;

--- a/BlockSettleUILib/Trading/ReqXBTSettlementContainer.h
+++ b/BlockSettleUILib/Trading/ReqXBTSettlementContainer.h
@@ -136,7 +136,7 @@ private:
    bs::Address       dealerAuthAddress_;
 
    bs::core::wallet::TXSignRequest        unsignedPayinRequest_;
-   BinaryData                    usedPayinHash_;
+   BinaryData                    expectedPayinHash_;
    std::map<UTXO, std::string>   utxosPayinFixed_;
 
    bool tradeCancelled_ = false;


### PR DESCRIPTION
Signed PayIn hash should be compared to an expected pay-in hash. There are no hash calculation on terminal side prior to sign.