### PR TITLE
Do not show error for non-participant (chat only) login

### DIFF
--- a/BlockSettleUILib/BSTerminalMainWindow.cpp
+++ b/BlockSettleUILib/BSTerminalMainWindow.cpp
@@ -1522,7 +1522,7 @@ void BSTerminalMainWindow::onAccountTypeChanged(bs::network::UserType userType, 
 {
    userType_ = userType;
 
-   if (enabled != accountEnabled_) {
+   if (enabled != accountEnabled_ && userType != bs::network::UserType::Chat) {
       accountEnabled_ = enabled;
       NotificationCenter::notify(enabled ? bs::ui::NotifyType::AccountEnabled : bs::ui::NotifyType::AccountDisabled, {});
    }


### PR DESCRIPTION
Do not show "account disabled" message for chat-only logins