### PR TITLE
Fix deb for ubuntu 20.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -757,7 +757,7 @@ ELSE(WIN32)
             ${ZLIB_LIBRARIES}
             png
             m
-            double-conversion
+            double-conversion.a
             dl
             cups
             udev

--- a/Deploy/Ubuntu/DEBIAN/control
+++ b/Deploy/Ubuntu/DEBIAN/control
@@ -7,7 +7,7 @@ Depends: desktop-file-utils, libc6 (>= 2.3.5-1), libstdc++6 (>= 6.3.0), libx11-x
          zlib1g (>= 1:1.2.1), libxcb-xinerama0 (>= 1.10),
          xdg-utils, libx11-6, libxcb-xkb1, libxcb-render-util0, libxcb-xfixes0,
          libxcb-randr0, libxcb-image0, libxcb-keysyms1, libxcb-icccm4,
-         libxkbcommon-x11-0, libdouble-conversion1, libcups2, libfontconfig1,
+         libxkbcommon-x11-0, libcups2, libfontconfig1,
          libxi6, libsm6, libxrender1, libxcb-sync1, libxcb-shape0
 Replaces: bsterminal (<< 0.7.0)
 Installed-Size: 125000


### PR DESCRIPTION
Tested installing deb file on Ubuntu 20.4, seems to work fine.