### PR TITLE
Disable auto-resizing on tutorials dialog to avoid flickering

### DIFF
--- a/BlockSettleUILib/InfoDialogs/AboutDialog.ui
+++ b/BlockSettleUILib/InfoDialogs/AboutDialog.ui
@@ -16,7 +16,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>468</width>
+    <width>400</width>
     <height>400</height>
    </rect>
   </property>

--- a/BlockSettleUILib/InfoDialogs/SupportDialog.ui
+++ b/BlockSettleUILib/InfoDialogs/SupportDialog.ui
@@ -15,23 +15,32 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>350</height>
+    <height>400</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="minimumSize">
    <size>
     <width>400</width>
-    <height>350</height>
+    <height>400</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>400</width>
-    <height>350</height>
+    <height>400</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Help</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>false</bool>
   </property>
   <property name="classicTabs" stdset="0">
    <bool>false</bool>


### PR DESCRIPTION
Disable auto-resizing on tutorials dialog to avoid flickering on windows while moving dialog with mouse