### PR TITLE
Bip21 bitpay support

### DIFF
--- a/BlockSettleUILib/BSTerminalMainWindow.cpp
+++ b/BlockSettleUILib/BSTerminalMainWindow.cpp
@@ -2404,14 +2404,28 @@ void BSTerminalMainWindow::addDeferredDialog(const std::function<void(void)> &de
 
 void BSTerminalMainWindow::openURIDialog()
 {
-   OpenURIDialog dlg{this};
+   const bool testnetNetwork = applicationSettings_->get<NetworkType>(ApplicationSettings::netType) == NetworkType::TestNet;
+
+   auto uiLogger = logMgr_->logger("ui");
+
+   OpenURIDialog dlg{connectionManager_->GetNAM(), testnetNetwork, uiLogger, this};
    if (dlg.exec() == QDialog::Accepted) {
       // open create transaction dialog
 
       const auto requestInfo = dlg.getRequestInfo();
-      // if (applicationSettings_->get<bool>(ApplicationSettings::AdvancedTxDialogByDefault)) {
+      std::shared_ptr<CreateTransactionDialog> cerateTxDlg;
 
-      // }
+      if (applicationSettings_->get<bool>(ApplicationSettings::AdvancedTxDialogByDefault)) {
+         cerateTxDlg = CreateTransactionDialogAdvanced::CreateForPaymentRequest(armory_, walletsMgr_
+            , utxoReservationMgr_, signContainer_, uiLogger, applicationSettings_
+            , requestInfo, this);
+      } else {
+         cerateTxDlg = CreateTransactionDialogSimple::CreateForPaymentRequest(armory_, walletsMgr_
+            , utxoReservationMgr_, signContainer_, uiLogger, applicationSettings_
+            , requestInfo, this);
+      }
+
+      DisplayCreateTransactionDialog(cerateTxDlg);
    }
 }
 

--- a/BlockSettleUILib/BSTerminalMainWindow.cpp
+++ b/BlockSettleUILib/BSTerminalMainWindow.cpp
@@ -1299,6 +1299,7 @@ void BSTerminalMainWindow::setupMenu()
    };
 
    connect(ui_->actionCreateNewWallet, &QAction::triggered, this, [ww = ui_->widgetWallets]{ ww->onNewWallet(); });
+   connect(ui_->actionOpenURI, &QAction::triggered, this, [this]{ openURIDialog(); });
    connect(ui_->actionAuthenticationAddresses, &QAction::triggered, this, &BSTerminalMainWindow::openAuthManagerDialog);
    connect(ui_->actionSettings, &QAction::triggered, this, [=]() { openConfigDialog(); });
    connect(ui_->actionAccountInformation, &QAction::triggered, this, &BSTerminalMainWindow::openAccountInfoDialog);
@@ -2405,3 +2406,6 @@ void BSTerminalMainWindow::addDeferredDialog(const std::function<void(void)> &de
       processDeferredDialogs();
    }, Qt::QueuedConnection);
 }
+
+void BSTerminalMainWindow::openURIDialog()
+{}

--- a/BlockSettleUILib/BSTerminalMainWindow.h
+++ b/BlockSettleUILib/BSTerminalMainWindow.h
@@ -133,6 +133,8 @@ private:
    bool showStartupDialog();
    void setWidgetsAuthorized(bool authorized);
 
+   void openURIDialog();
+
 signals:
    void armoryServerPromptResultReady();
 

--- a/BlockSettleUILib/BSTerminalMainWindow.h
+++ b/BlockSettleUILib/BSTerminalMainWindow.h
@@ -53,13 +53,14 @@ class AuthAddressDialog;
 class AuthAddressManager;
 class AutheIDClient;
 class AutoSignScriptProvider;
+class BaseCelerClient;
 class BSMarketDataProvider;
 class BSTerminalSplashScreen;
-class BaseCelerClient;
 class CCFileManager;
 class CCPortfolioModel;
 class CcTrackerClient;
 class ConnectionManager;
+class CreateTransactionDialog;
 class LoginWindow;
 class MDCallbacksQt;
 class OrderListModel;
@@ -282,6 +283,8 @@ private:
    const std::string &loginApiKeyEncrypted() const;
    void initApiKeyLogins();
    void tryLoginUsingApiKey();
+
+   void DisplayCreateTransactionDialog(std::shared_ptr<CreateTransactionDialog> dlg);
 
 private:
    enum class ChatInitState

--- a/BlockSettleUILib/BSTerminalMainWindow.ui
+++ b/BlockSettleUILib/BSTerminalMainWindow.ui
@@ -539,7 +539,7 @@
      <x>0</x>
      <y>0</y>
      <width>1600</width>
-     <height>21</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -549,6 +549,7 @@
     <addaction name="actionSettings"/>
     <addaction name="separator"/>
     <addaction name="actionCreateNewWallet"/>
+    <addaction name="actionOpenURI"/>
     <addaction name="separator"/>
     <addaction name="actionAbout"/>
     <addaction name="separator"/>
@@ -911,6 +912,14 @@
   <action name="actionVideoTutorials">
    <property name="text">
     <string>Video Tutorials</string>
+   </property>
+  </action>
+  <action name="actionOpenURI">
+   <property name="text">
+    <string>&amp;Open URI</string>
+   </property>
+   <property name="toolTip">
+    <string>Open bitcoin URI or payment request</string>
    </property>
   </action>
  </widget>

--- a/BlockSettleUILib/CreateTransactionDialog.cpp
+++ b/BlockSettleUILib/CreateTransactionDialog.cpp
@@ -524,7 +524,18 @@ void CreateTransactionDialog::CreateTransaction(const CreateTransactionCb &cb)
                if (!handle.isValid()) {
                   return;
                }
-               logger_->debug("[{}] result={}, state: {}", __func__, (int)result, state.IsInitialized());
+
+               const auto serializedUnsigned = txReq_.armorySigner_.serializeUnsignedTx().toHexStr();
+               const auto estimatedSize = txReq_.estimateTxVirtSize();
+
+               if (!verifyUnsignedTx(serializedUnsigned, estimatedSize)) {
+                  logger_->debug("[CreateTransactionDialog::CreateTransaction cbResolvePublicData] rejected by verifyUnsignedTx");
+                  cb(false, "user verification failed");
+                  return;
+               }
+
+               logger_->debug("[CreateTransactionDialog::CreateTransaction cbResolvePublicData] result={}, state: {}"
+                              , (int)result, state.IsInitialized());
                bool rc = createTransactionImpl();
                cb(rc, rc ? "" : "unknown error");
             };

--- a/BlockSettleUILib/CreateTransactionDialog.cpp
+++ b/BlockSettleUILib/CreateTransactionDialog.cpp
@@ -14,31 +14,33 @@
 #include <thread>
 
 #include <QCheckBox>
+#include <QCloseEvent>
 #include <QComboBox>
 #include <QCoreApplication>
+#include <QFile>
+#include <QFileDialog>
+#include <QIntValidator>
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
 #include <QTextEdit>
-#include <QIntValidator>
-#include <QFile>
-#include <QFileDialog>
-#include <QCloseEvent>
+
 #include <spdlog/spdlog.h>
+
 #include "Address.h"
 #include "ArmoryConnection.h"
 #include "BSMessageBox.h"
 #include "OfflineSigner.h"
+#include "SelectedTransactionInputs.h"
 #include "SignContainer.h"
 #include "TransactionData.h"
 #include "TransactionOutputsModel.h"
 #include "UiUtils.h"
 #include "UsedInputsModel.h"
+#include "UtxoReservationManager.h"
 #include "Wallets/SyncHDWallet.h"
 #include "Wallets/SyncWalletsManager.h"
 #include "XbtAmountValidator.h"
-#include "UtxoReservationManager.h"
-#include "SelectedTransactionInputs.h"
 
 // Mirror of cached Armory wait times - NodeRPC::aggregateFeeEstimates()
 const std::map<unsigned int, QString> feeLevels = {

--- a/BlockSettleUILib/CreateTransactionDialog.cpp
+++ b/BlockSettleUILib/CreateTransactionDialog.cpp
@@ -726,3 +726,8 @@ void CreateTransactionDialog::showError(const QString &text, const QString &deta
    BSMessageBox errorMessage(BSMessageBox::critical, text, detailedText, this);
    errorMessage.exec();
 }
+
+bool CreateTransactionDialog::canUseSimpleMode(const Bip21::PaymentRequestInfo& paymentInfo)
+{
+   return paymentInfo.requestURL.isEmpty();
+}

--- a/BlockSettleUILib/CreateTransactionDialog.h
+++ b/BlockSettleUILib/CreateTransactionDialog.h
@@ -21,6 +21,7 @@
 #include <QPoint>
 #include <QString>
 
+#include "Bip21Types.h"
 #include "BSErrorCodeStrings.h"
 #include "CoreWallet.h"
 #include "UtxoReservationToken.h"
@@ -129,6 +130,8 @@ protected slots:
 
 protected:
    void populateFeeList();
+
+   static bool canUseSimpleMode(const Bip21::PaymentRequestInfo& paymentInfo);
 
 private:
    void loadFees();

--- a/BlockSettleUILib/CreateTransactionDialog.h
+++ b/BlockSettleUILib/CreateTransactionDialog.h
@@ -109,12 +109,11 @@ protected:
 
    std::vector<bs::core::wallet::TXSignRequest> ImportTransactions();
    bool BroadcastImportedTx();
-   using CreateTransactionCb = std::function<void(bool success, const std::string &errorMsg)>;
+   using CreateTransactionCb = std::function<void(bool success, const std::string &errorMsg
+                                                  , const std::string& unsignedTx, uint64_t virtSize)>;
    void CreateTransaction(const CreateTransactionCb &cb);
 
    void showError(const QString &text, const QString &detailedText);
-
-   virtual bool verifyUnsignedTx(const std::string& unsignedTx, uint64_t virtSize) = 0;
 
 signals:
    void feeLoadingCompleted(const std::map<unsigned int, float> &);
@@ -133,6 +132,8 @@ protected slots:
 protected:
    void populateFeeList();
 
+   bool createTransactionImpl();
+
    static bool canUseSimpleMode(const Bip21::PaymentRequestInfo& paymentInfo);
 
 private:
@@ -140,7 +141,6 @@ private:
    void populateWalletsList();
    void startBroadcasting();
    void stopBroadcasting();
-   bool createTransactionImpl();
 
 protected:
    std::shared_ptr<ArmoryConnection>   armory_;

--- a/BlockSettleUILib/CreateTransactionDialog.h
+++ b/BlockSettleUILib/CreateTransactionDialog.h
@@ -114,6 +114,8 @@ protected:
 
    void showError(const QString &text, const QString &detailedText);
 
+   virtual bool verifyUnsignedTx(const std::string& unsignedTx, uint64_t virtSize) = 0;
+
 signals:
    void feeLoadingCompleted(const std::map<unsigned int, float> &);
    void walletChanged();

--- a/BlockSettleUILib/CreateTransactionDialog.h
+++ b/BlockSettleUILib/CreateTransactionDialog.h
@@ -11,18 +11,20 @@
 #ifndef __CREATE_TRANSACTION_DIALOG_H__
 #define __CREATE_TRANSACTION_DIALOG_H__
 
-#include <vector>
 #include <memory>
 #include <string>
+#include <vector>
+
 #include <QAction>
 #include <QDialog>
 #include <QMenu>
 #include <QPoint>
 #include <QString>
+
 #include "BSErrorCodeStrings.h"
 #include "CoreWallet.h"
-#include "ValidityFlag.h"
 #include "UtxoReservationToken.h"
+#include "ValidityFlag.h"
 
 namespace bs {
    namespace sync {
@@ -68,7 +70,7 @@ public:
    int SelectWallet(const std::string& walletId, UiUtils::WalletsTypes type);
 
    virtual bool switchModeRequested() const= 0;
-   virtual std::shared_ptr<CreateTransactionDialog> SwithcMode() = 0;
+   virtual std::shared_ptr<CreateTransactionDialog> SwitchMode() = 0;
 
 protected:
    virtual void init();

--- a/BlockSettleUILib/CreateTransactionDialogAdvanced.cpp
+++ b/BlockSettleUILib/CreateTransactionDialogAdvanced.cpp
@@ -33,6 +33,7 @@
 #include <QFileDialog>
 #include <QKeyEvent>
 #include <QPushButton>
+
 #include <spdlog/spdlog.h>
 #include <stdexcept>
 
@@ -1675,7 +1676,7 @@ bool CreateTransactionDialogAdvanced::switchModeRequested() const
    return simpleDialogRequested_;
 }
 
-std::shared_ptr<CreateTransactionDialog> CreateTransactionDialogAdvanced::SwithcMode()
+std::shared_ptr<CreateTransactionDialog> CreateTransactionDialogAdvanced::SwitchMode()
 {
    auto simpleDialog = std::make_shared<CreateTransactionDialogSimple>(armory_
       , walletsManager_, utxoReservationManager_, signContainer_

--- a/BlockSettleUILib/CreateTransactionDialogAdvanced.cpp
+++ b/BlockSettleUILib/CreateTransactionDialogAdvanced.cpp
@@ -153,7 +153,9 @@ std::shared_ptr<CreateTransactionDialog> CreateTransactionDialogAdvanced::Create
    }
 
    // set message or label to comment
-   if (!paymentInfo.message.isEmpty()) {
+   if (!paymentInfo.requestMemo.isEmpty()) {
+      dlg->ui_->textEditComment->setText(paymentInfo.requestMemo);
+   } else if (!paymentInfo.message.isEmpty()) {
       dlg->ui_->textEditComment->setText(paymentInfo.message);
    } else if (!paymentInfo.label.isEmpty()) {
       dlg->ui_->textEditComment->setText(paymentInfo.label);
@@ -1773,4 +1775,9 @@ std::shared_ptr<CreateTransactionDialog> CreateTransactionDialogAdvanced::Switch
    }
 
    return simpleDialog;
+}
+
+bool CreateTransactionDialogAdvanced::verifyUnsignedTx(const std::string& unsignedTx, uint64_t virtSize)
+{
+   return true;
 }

--- a/BlockSettleUILib/CreateTransactionDialogAdvanced.h
+++ b/BlockSettleUILib/CreateTransactionDialogAdvanced.h
@@ -115,6 +115,8 @@ protected:
 
    bool HaveSignedImportedTransaction() const override;
 
+   bool verifyUnsignedTx(const std::string& unsignedTx, uint64_t virtSize) override;
+
 protected slots:
    void onAddressTextChanged(const QString& addressString);
    void onFeeSuggestionsLoaded(const std::map<unsigned int, float> &) override;

--- a/BlockSettleUILib/CreateTransactionDialogAdvanced.h
+++ b/BlockSettleUILib/CreateTransactionDialogAdvanced.h
@@ -73,7 +73,7 @@ public:
    void SetImportedTransactions(const std::vector<bs::core::wallet::TXSignRequest>& transactions);
 
    bool switchModeRequested() const override;
-   std::shared_ptr<CreateTransactionDialog> SwithcMode() override;
+   std::shared_ptr<CreateTransactionDialog> SwitchMode() override;
 
 protected:
    bool eventFilter(QObject *watched, QEvent *) override;

--- a/BlockSettleUILib/CreateTransactionDialogAdvanced.h
+++ b/BlockSettleUILib/CreateTransactionDialogAdvanced.h
@@ -54,6 +54,16 @@ public:
       , const Tx &
       , QWidget* parent = nullptr);
 
+   static std::shared_ptr<CreateTransactionDialog> CreateForPaymentRequest(
+        const std::shared_ptr<ArmoryConnection> &
+      , const std::shared_ptr<bs::sync::WalletsManager> &
+      , const std::shared_ptr<bs::UTXOReservationManager> &
+      , const std::shared_ptr<SignContainer>&
+      , const std::shared_ptr<spdlog::logger>&
+      , const std::shared_ptr<ApplicationSettings> &
+      , const Bip21::PaymentRequestInfo& paymentInfo
+      , QWidget* parent = nullptr);
+
 public:
    CreateTransactionDialogAdvanced(const std::shared_ptr<ArmoryConnection> &
       , const std::shared_ptr<bs::sync::WalletsManager> &
@@ -169,6 +179,7 @@ private:
    void enableFeeChanging(bool flag = true);
    void SetFixedChangeAddress(const QString& changeAddress);
    void SetPredefinedFee(const int64_t& manualFee);
+   void SetPredefinedFeeRate(const float feeRate);
    void setUnchangeableTx();
 
    void RemoveOutputByRow(int row);
@@ -204,6 +215,7 @@ private:
    bool        simpleDialogRequested_ = false;
 
    bs::XBTAmount importedTxTotalFee_{};
+   Bip21::PaymentRequestInfo paymentInfo_;
 };
 
 #endif // __CREATE_TRANSACTION_DIALOG_ADVANCED_H__

--- a/BlockSettleUILib/CreateTransactionDialogAdvanced.h
+++ b/BlockSettleUILib/CreateTransactionDialogAdvanced.h
@@ -27,6 +27,7 @@ namespace bs {
    }
 }
 
+class QNetworkAccessManager;
 
 class CreateTransactionDialogAdvanced : public CreateTransactionDialog
 {
@@ -115,8 +116,6 @@ protected:
 
    bool HaveSignedImportedTransaction() const override;
 
-   bool verifyUnsignedTx(const std::string& unsignedTx, uint64_t virtSize) override;
-
 protected slots:
    void onAddressTextChanged(const QString& addressString);
    void onFeeSuggestionsLoaded(const std::map<unsigned int, float> &) override;
@@ -142,6 +141,11 @@ private slots:
    void onOutputsClicked(const QModelIndex &index);
    void onSimpleDialogRequested();
    void onUpdateChangeWidget();
+   void onBitPayTxVerified(bool result);
+   void onVerifyBitPayUnsignedTx(const std::string& unsignedTx, uint64_t virtSize);
+signals:
+   void VerifyBitPayUnsignedTx(const std::string& unsignedTx, uint64_t virtSize);
+   void BitPayTxVerified(bool result);
 
 private:
    void clear() override;
@@ -218,6 +222,8 @@ private:
 
    bs::XBTAmount importedTxTotalFee_{};
    Bip21::PaymentRequestInfo paymentInfo_;
+
+   std::shared_ptr<QNetworkAccessManager> nam_;
 };
 
 #endif // __CREATE_TRANSACTION_DIALOG_ADVANCED_H__

--- a/BlockSettleUILib/CreateTransactionDialogSimple.cpp
+++ b/BlockSettleUILib/CreateTransactionDialogSimple.cpp
@@ -336,3 +336,8 @@ std::shared_ptr<CreateTransactionDialog> CreateTransactionDialogSimple::CreateFo
 
    return dlg;
 }
+
+bool CreateTransactionDialogSimple::verifyUnsignedTx(const std::string&, uint64_t)
+{
+   return true;
+}

--- a/BlockSettleUILib/CreateTransactionDialogSimple.cpp
+++ b/BlockSettleUILib/CreateTransactionDialogSimple.cpp
@@ -211,7 +211,7 @@ void CreateTransactionDialogSimple::createTransaction()
       return;
    }
 
-   CreateTransaction([this, handle = validityFlag_.handle()](bool result, const std::string &errorMsg) {
+   CreateTransaction([this, handle = validityFlag_.handle()](bool result, const std::string &errorMsg, const std::string& unsignedTx, uint64_t virtSize) {
       if (!handle.isValid()) {
          return;
       }
@@ -220,6 +220,8 @@ void CreateTransactionDialogSimple::createTransaction()
             , tr("Transaction error"), QString::fromStdString(errorMsg)).exec();
          reject();
       }
+
+      createTransactionImpl();
    });
 }
 
@@ -335,9 +337,4 @@ std::shared_ptr<CreateTransactionDialog> CreateTransactionDialogSimple::CreateFo
    dlg->paymentInfo_ = paymentInfo;
 
    return dlg;
-}
-
-bool CreateTransactionDialogSimple::verifyUnsignedTx(const std::string&, uint64_t)
-{
-   return true;
 }

--- a/BlockSettleUILib/CreateTransactionDialogSimple.cpp
+++ b/BlockSettleUILib/CreateTransactionDialogSimple.cpp
@@ -228,7 +228,7 @@ bool CreateTransactionDialogSimple::switchModeRequested() const
    return advancedDialogRequested_;
 }
 
-std::shared_ptr<CreateTransactionDialog> CreateTransactionDialogSimple::SwithcMode()
+std::shared_ptr<CreateTransactionDialog> CreateTransactionDialogSimple::SwitchMode()
 {
    auto advancedDialog = std::make_shared<CreateTransactionDialogAdvanced>(armory_, walletsManager_
       , utxoReservationManager_, signContainer_, true, logger_, applicationSettings_, transactionData_, std::move(utxoRes_), parentWidget());

--- a/BlockSettleUILib/CreateTransactionDialogSimple.cpp
+++ b/BlockSettleUILib/CreateTransactionDialogSimple.cpp
@@ -230,6 +230,11 @@ bool CreateTransactionDialogSimple::switchModeRequested() const
 
 std::shared_ptr<CreateTransactionDialog> CreateTransactionDialogSimple::SwitchMode()
 {
+   if (!paymentInfo_.address.isEmpty()) {
+      return CreateTransactionDialogAdvanced::CreateForPaymentRequest(armory_, walletsManager_
+         , utxoReservationManager_, signContainer_, logger_, applicationSettings_, paymentInfo_, parentWidget());
+   }
+
    auto advancedDialog = std::make_shared<CreateTransactionDialogAdvanced>(armory_, walletsManager_
       , utxoReservationManager_, signContainer_, true, logger_, applicationSettings_, transactionData_, std::move(utxoRes_), parentWidget());
 
@@ -285,4 +290,49 @@ void CreateTransactionDialogSimple::preSetAddress(const QString& address)
 void CreateTransactionDialogSimple::preSetValue(const double value)
 {
    ui_->lineEditAmount->setText(UiUtils::displayAmount(value));
+}
+
+void CreateTransactionDialogSimple::preSetValue(const bs::XBTAmount& value)
+{
+   ui_->lineEditAmount->setText(UiUtils::displayAmount(value));
+}
+
+std::shared_ptr<CreateTransactionDialog> CreateTransactionDialogSimple::CreateForPaymentRequest(const std::shared_ptr<ArmoryConnection> &armory
+   , const std::shared_ptr<bs::sync::WalletsManager>& walletManager
+   , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
+   , const std::shared_ptr<SignContainer> &container
+   , const std::shared_ptr<spdlog::logger>& logger
+   , const std::shared_ptr<ApplicationSettings> &applicationSettings
+   , const Bip21::PaymentRequestInfo& paymentInfo
+   , QWidget* parent)
+{
+   if (!canUseSimpleMode(paymentInfo)) {
+      return CreateTransactionDialogAdvanced::CreateForPaymentRequest(armory, walletManager
+         , utxoReservationManager, container, logger, applicationSettings, paymentInfo, parent);
+   }
+
+   auto dlg = std::make_shared<CreateTransactionDialogSimple>(armory, walletManager
+      , utxoReservationManager, container, logger, applicationSettings, parent);
+
+   // set address and lock
+   dlg->preSetAddress(paymentInfo.address);
+   dlg->ui_->lineEditAddress->setEnabled(false);
+
+   // set amount and lock
+   if (paymentInfo.amount.GetValue() != 0) {
+      dlg->preSetValue(paymentInfo.amount);
+      dlg->ui_->lineEditAmount->setEnabled(false);
+      dlg->ui_->pushButtonMax->setEnabled(false);
+   }
+
+   // set message or label to comment
+   if (!paymentInfo.message.isEmpty()) {
+      dlg->ui_->textEditComment->setText(paymentInfo.message);
+   } else if (!paymentInfo.label.isEmpty()) {
+      dlg->ui_->textEditComment->setText(paymentInfo.label);
+   }
+
+   dlg->paymentInfo_ = paymentInfo;
+
+   return dlg;
 }

--- a/BlockSettleUILib/CreateTransactionDialogSimple.h
+++ b/BlockSettleUILib/CreateTransactionDialogSimple.h
@@ -76,8 +76,6 @@ protected:
 
    void getChangeAddress(AddressCb cb) const override;
 
-   bool verifyUnsignedTx(const std::string& unsignedTx, uint64_t virtSize) override;
-
 protected slots:
    void onMaxPressed() override;
    void onTransactionUpdated() override;

--- a/BlockSettleUILib/CreateTransactionDialogSimple.h
+++ b/BlockSettleUILib/CreateTransactionDialogSimple.h
@@ -25,6 +25,17 @@ class CreateTransactionDialogSimple : public CreateTransactionDialog
 Q_OBJECT
 
 public:
+   static std::shared_ptr<CreateTransactionDialog> CreateForPaymentRequest(
+        const std::shared_ptr<ArmoryConnection> &
+      , const std::shared_ptr<bs::sync::WalletsManager> &
+      , const std::shared_ptr<bs::UTXOReservationManager> &
+      , const std::shared_ptr<SignContainer>&
+      , const std::shared_ptr<spdlog::logger>&
+      , const std::shared_ptr<ApplicationSettings> &
+      , const Bip21::PaymentRequestInfo& paymentInfo
+      , QWidget* parent = nullptr);
+
+public:
    CreateTransactionDialogSimple(const std::shared_ptr<ArmoryConnection> &
       , const std::shared_ptr<bs::sync::WalletsManager> &
       , const std::shared_ptr<bs::UTXOReservationManager> &utxoReservationManager
@@ -39,6 +50,8 @@ public:
 
    void preSetAddress(const QString& address);
    void preSetValue(const double value);
+   void preSetValue(const bs::XBTAmount& value);
+
 
 protected:
    QComboBox * comboBoxWallets() const override;
@@ -82,6 +95,8 @@ private:
    bool  advancedDialogRequested_ = false;
 
    std::vector<bs::core::wallet::TXSignRequest> offlineTransactions_;
+
+   Bip21::PaymentRequestInfo paymentInfo_;
 };
 
 #endif // __CREATE_TRANSACTION_DIALOG_SIMPLE_H__

--- a/BlockSettleUILib/CreateTransactionDialogSimple.h
+++ b/BlockSettleUILib/CreateTransactionDialogSimple.h
@@ -76,6 +76,8 @@ protected:
 
    void getChangeAddress(AddressCb cb) const override;
 
+   bool verifyUnsignedTx(const std::string& unsignedTx, uint64_t virtSize) override;
+
 protected slots:
    void onMaxPressed() override;
    void onTransactionUpdated() override;

--- a/BlockSettleUILib/CreateTransactionDialogSimple.h
+++ b/BlockSettleUILib/CreateTransactionDialogSimple.h
@@ -35,7 +35,7 @@ public:
    ~CreateTransactionDialogSimple() override;
 
    bool switchModeRequested() const override;
-   std::shared_ptr<CreateTransactionDialog> SwithcMode() override;
+   std::shared_ptr<CreateTransactionDialog> SwitchMode() override;
 
    void preSetAddress(const QString& address);
    void preSetValue(const double value);

--- a/BlockSettleUILib/OpenURIDialog.cpp
+++ b/BlockSettleUILib/OpenURIDialog.cpp
@@ -1,0 +1,30 @@
+/*
+
+***********************************************************************************
+* Copyright (C) 2020, BlockSettle AB
+* Distributed under the GNU Affero General Public License (AGPL v3)
+* See LICENSE or http://www.gnu.org/licenses/agpl.html
+*
+**********************************************************************************
+
+*/
+#include "OpenURIDialog.h"
+#include "ui_OpenURIDialog.h"
+
+#include <QLineEdit>
+#include <QPushButton>
+
+#include <spdlog/spdlog.h>
+
+
+OpenURIDialog::OpenURIDialog(QWidget *parent)
+   : QDialog(parent)
+   , ui_(new Ui::OpenURIDialog())
+{
+   ui_->setupUi(this);
+
+   connect(ui_->pushButtonOk, &QPushButton::clicked, this, &QDialog::accept);
+   connect(ui_->pushButtonCancel, &QPushButton::clicked, this, &QDialog::reject);
+}
+
+OpenURIDialog::~OpenURIDialog() = default;

--- a/BlockSettleUILib/OpenURIDialog.cpp
+++ b/BlockSettleUILib/OpenURIDialog.cpp
@@ -54,7 +54,7 @@ OpenURIDialog::OpenURIDialog(const std::shared_ptr<QNetworkAccessManager>& nam
    connect(ui_->pushButtonOk, &QPushButton::clicked, this, &QDialog::accept);
    connect(ui_->pushButtonCancel, &QPushButton::clicked, this, &QDialog::reject);
 
-   connect(ui_->lineEditURI, &QLineEdit::textEdited, this, &OpenURIDialog::onURIChanhed);
+   connect(ui_->lineEditURI, &QLineEdit::textEdited, this, &OpenURIDialog::onURIChanged);
 
    connect(this, &OpenURIDialog::BitpayPaymentLoaded, this, &OpenURIDialog::onBitpayPaymentLoaded);
 
@@ -65,7 +65,7 @@ OpenURIDialog::OpenURIDialog(const std::shared_ptr<QNetworkAccessManager>& nam
 
 OpenURIDialog::~OpenURIDialog() = default;
 
-void OpenURIDialog::onURIChanhed()
+void OpenURIDialog::onURIChanged()
 {
    ClearErrorText();
    ClearStatusText();

--- a/BlockSettleUILib/OpenURIDialog.cpp
+++ b/BlockSettleUILib/OpenURIDialog.cpp
@@ -395,9 +395,8 @@ void OpenURIDialog::DisplayRequestDetails()
       }
 
       ui_->labelDetailsFeeRate->setText(tr("%1 s/b").arg(requestInfo_.feePerByte));
+      ui_->labelDetailsMemo->setText(requestInfo_.requestMemo);
    }
-
-
 }
 
 void OpenURIDialog::ClearRequestDetailsOnUI()

--- a/BlockSettleUILib/OpenURIDialog.cpp
+++ b/BlockSettleUILib/OpenURIDialog.cpp
@@ -9,13 +9,27 @@
 
 */
 #include "OpenURIDialog.h"
+
 #include "ui_OpenURIDialog.h"
+
+#include "Address.h"
+#include "UiUtils.h"
 
 #include <QLineEdit>
 #include <QPushButton>
+#include <QUrl>
+#include <QUrlQuery>
 
 #include <spdlog/spdlog.h>
 
+const QString kBitcoinSchemePrefix = QStringLiteral("bitcoin:");
+const QString kBitPayTestPrefix = QStringLiteral("https://test.bitpay.com/");
+const QString kBitPayPrefix = QStringLiteral("https://bitpay.com/");
+
+const QString kLabelKey = QStringLiteral("label");
+const QString kMessageKey = QStringLiteral("message");
+const QString kAmountKey = QStringLiteral("amount");
+const QString kRequestKey = QStringLiteral("r");
 
 OpenURIDialog::OpenURIDialog(QWidget *parent)
    : QDialog(parent)
@@ -25,6 +39,164 @@ OpenURIDialog::OpenURIDialog(QWidget *parent)
 
    connect(ui_->pushButtonOk, &QPushButton::clicked, this, &QDialog::accept);
    connect(ui_->pushButtonCancel, &QPushButton::clicked, this, &QDialog::reject);
+
+   connect(ui_->lineEditURI, &QLineEdit::textEdited, this, &OpenURIDialog::onURIChanhed);
+
+   ClearErrorText();
+   ClearStatusText();
+   ClearRequestDetailsOnUI();
 }
 
 OpenURIDialog::~OpenURIDialog() = default;
+
+void OpenURIDialog::onURIChanhed()
+{
+   ClearErrorText();
+   ClearStatusText();
+
+   if (ParseURI()) {
+      DisplayRequestDetails();
+      ui_->pushButtonOk->setEnabled(true);
+   } else {
+      ClearRequestDetailsOnUI();
+      ui_->pushButtonOk->setEnabled(false);
+   }
+}
+
+bool OpenURIDialog::ParseURI()
+{
+   const auto text = ui_->lineEditURI->text().trimmed();
+   if (text.isEmpty() || text.length() < kBitcoinSchemePrefix.length()) {
+      return false;
+   }
+
+   if (!text.startsWith(kBitcoinSchemePrefix, Qt::CaseInsensitive)) {
+      SetErrorText(tr("Invalid schema"));
+      return false;
+   }
+
+   QUrl uri{text};
+
+   if (!uri.isValid()) {
+      return false;
+   }
+
+   PaymentRequestInfo info;
+
+   info.address = uri.path();
+
+   if (!info.address.isEmpty()) {
+
+      bs::Address address;
+      try {
+         address = bs::Address::fromAddressString(info.address.toStdString());
+      } catch(...) {
+      }
+
+      if (!address.isValid()) {
+         SetErrorText(tr("Invalid address format. Check Url or network"));
+         return false;
+      }
+   }
+
+   QUrlQuery uriQuery(uri);
+   const auto items = uriQuery.queryItems();
+   for (const auto& i : items) {
+      if (i.first == kLabelKey) {
+         info.label = i.second;
+      } else if (i.first == kMessageKey) {
+         info.message = i.second;
+      } else if (i.first == kAmountKey) {
+         bool converted = false;
+         double value = UiUtils::parseAmountBtc(i.second, &converted);
+
+         if (!converted || value < 0) {
+            SetErrorText(tr("Invalid amount format."));
+            return false;
+         }
+
+         info.amount.SetValueBitcoin(value);
+         if (info.amount.GetValue() == 0) {
+            SetErrorText(tr("Amount could not be 0."));
+            return false;
+         }
+      } else if (i.first == kRequestKey) {
+         // check that request is from bit pay
+         // reject if not
+         // BIP70 is not supported by default in bitcoin-qt client
+
+         const auto requestURL = i.second;
+         if (!(requestURL.startsWith(kBitPayTestPrefix, Qt::CaseInsensitive) || requestURL.startsWith(kBitPayPrefix, Qt::CaseInsensitive))) {
+            SetErrorText(tr("BIP70 supported for BitPay only."));
+            return false;
+         }
+
+         info.requestURL = requestURL;
+      }
+   }
+
+   requestInfo_ = info;
+
+   return true;
+}
+
+void OpenURIDialog::DisplayRequestDetails()
+{
+   ui_->labelDetailsAddress->setText(requestInfo_.address);
+   ui_->labelDetailsLabel->setText(requestInfo_.label);
+   ui_->labelDetailsMessage->setText(requestInfo_.message);
+
+   if (requestInfo_.amount.GetValue() == 0) {
+      ui_->labelDetilsAmount->clear();
+   } else {
+      ui_->labelDetilsAmount->setText(UiUtils::displayAmount(requestInfo_.amount));
+   }
+
+   if (!requestInfo_.requestURL.isEmpty()) {
+      ui_->labelRequestURL->setText(tr("<a href=\"%1\"><span style=\"font-size:12px; text-decoration: underline; color:#fefeff\">%1</span></a>").arg(requestInfo_.requestURL));
+   }
+}
+
+void OpenURIDialog::ClearRequestDetailsOnUI()
+{
+   requestInfo_ = PaymentRequestInfo{};
+
+   ui_->labelDetailsAddress->clear();
+   ui_->labelDetailsLabel->clear();
+   ui_->labelDetailsMessage->clear();
+   ui_->labelDetilsAmount->clear();
+   ui_->labelRequestURL->clear();
+
+   ui_->groupBoxBitPayDetails->hide();
+   ui_->labelDetailsExpires->clear();
+   ui_->labelDetailsFeeRate->clear();
+}
+
+void OpenURIDialog::SetErrorText(const QString& errorText)
+{
+   ui_->labelErrorMessage->setText(errorText);
+   ui_->labelErrorMessage->setVisible(true);
+   ui_->labelStatus->setVisible(false);
+}
+
+void OpenURIDialog::SetStatusText(const QString& statusText)
+{
+   ui_->labelStatus->setText(statusText);
+   ui_->labelErrorMessage->setVisible(false);
+   ui_->labelStatus->setVisible(true);
+}
+
+void OpenURIDialog::ClearErrorText()
+{
+   ui_->labelErrorMessage->setVisible(false);
+}
+
+void OpenURIDialog::ClearStatusText()
+{
+   ui_->labelStatus->setVisible(false);
+}
+
+OpenURIDialog::PaymentRequestInfo OpenURIDialog::getRequestInfo() const
+{
+   return requestInfo_;
+}

--- a/BlockSettleUILib/OpenURIDialog.h
+++ b/BlockSettleUILib/OpenURIDialog.h
@@ -12,13 +12,11 @@
 #define __OPEN_URI_DIALOG_H__
 
 #include <memory>
+
 #include <QDialog>
-#include <QTimer>
 
 #include "BinaryData.h"
-#include "BSErrorCode.h"
-#include "EncryptionUtils.h"
-#include "ValidityFlag.h"
+#include "XBTAmount.h"
 
 namespace Ui {
     class OpenURIDialog;
@@ -29,11 +27,38 @@ class OpenURIDialog : public QDialog
 Q_OBJECT
 
 public:
+   struct PaymentRequestInfo
+   {
+      QString        address;
+      bs::XBTAmount  amount;
+      QString        label;
+      QString        message;
+      QString        requestURL;
+   };
+
+public:
    OpenURIDialog(QWidget *parent);
    ~OpenURIDialog() override;
 
+   PaymentRequestInfo getRequestInfo() const;
+
+private slots:
+   void onURIChanhed();
+
 private:
-   std::unique_ptr<Ui::OpenURIDialog>   ui_;
+   bool ParseURI();
+
+   void DisplayRequestDetails();
+   void ClearRequestDetailsOnUI();
+
+   void SetErrorText(const QString& errorText);
+   void SetStatusText(const QString& statusText);
+   void ClearErrorText();
+   void ClearStatusText();
+
+private:
+   std::unique_ptr<Ui::OpenURIDialog>  ui_;
+   PaymentRequestInfo                  requestInfo_;
 };
 
 #endif // __OPEN_URI_DIALOG_H__

--- a/BlockSettleUILib/OpenURIDialog.h
+++ b/BlockSettleUILib/OpenURIDialog.h
@@ -1,0 +1,39 @@
+/*
+
+***********************************************************************************
+* Copyright (C) 2020, BlockSettle AB
+* Distributed under the GNU Affero General Public License (AGPL v3)
+* See LICENSE or http://www.gnu.org/licenses/agpl.html
+*
+**********************************************************************************
+
+*/
+#ifndef __OPEN_URI_DIALOG_H__
+#define __OPEN_URI_DIALOG_H__
+
+#include <memory>
+#include <QDialog>
+#include <QTimer>
+
+#include "BinaryData.h"
+#include "BSErrorCode.h"
+#include "EncryptionUtils.h"
+#include "ValidityFlag.h"
+
+namespace Ui {
+    class OpenURIDialog;
+}
+
+class OpenURIDialog : public QDialog
+{
+Q_OBJECT
+
+public:
+   OpenURIDialog(QWidget *parent);
+   ~OpenURIDialog() override;
+
+private:
+   std::unique_ptr<Ui::OpenURIDialog>   ui_;
+};
+
+#endif // __OPEN_URI_DIALOG_H__

--- a/BlockSettleUILib/OpenURIDialog.h
+++ b/BlockSettleUILib/OpenURIDialog.h
@@ -15,35 +15,38 @@
 
 #include <QDialog>
 
+#include <spdlog/spdlog.h>
+
 #include "BinaryData.h"
+#include "Bip21Types.h"
 #include "XBTAmount.h"
 
 namespace Ui {
     class OpenURIDialog;
 }
 
+class QNetworkAccessManager;
+
 class OpenURIDialog : public QDialog
 {
 Q_OBJECT
 
 public:
-   struct PaymentRequestInfo
-   {
-      QString        address;
-      bs::XBTAmount  amount;
-      QString        label;
-      QString        message;
-      QString        requestURL;
-   };
-
-public:
-   OpenURIDialog(QWidget *parent);
+   OpenURIDialog(const std::shared_ptr<QNetworkAccessManager>& nam
+                 , bool onTestnet
+                 , const std::shared_ptr<spdlog::logger> &logger
+                 , QWidget *parent = nullptr);
    ~OpenURIDialog() override;
 
-   PaymentRequestInfo getRequestInfo() const;
+   Bip21::PaymentRequestInfo getRequestInfo() const;
 
 private slots:
    void onURIChanhed();
+
+   void onBitpayPaymentLoaded(bool result);
+
+signals:
+   void BitpayPaymentLoaded(bool result);
 
 private:
    bool ParseURI();
@@ -56,9 +59,14 @@ private:
    void ClearErrorText();
    void ClearStatusText();
 
+   void LoadPaymentOptions();
+
 private:
-   std::unique_ptr<Ui::OpenURIDialog>  ui_;
-   PaymentRequestInfo                  requestInfo_;
+   std::unique_ptr<Ui::OpenURIDialog>     ui_;
+   Bip21::PaymentRequestInfo              requestInfo_;
+   std::shared_ptr<QNetworkAccessManager> nam_;
+   bool                                   onTestnet_;
+   std::shared_ptr<spdlog::logger>        logger_;
 };
 
 #endif // __OPEN_URI_DIALOG_H__

--- a/BlockSettleUILib/OpenURIDialog.h
+++ b/BlockSettleUILib/OpenURIDialog.h
@@ -41,7 +41,7 @@ public:
    Bip21::PaymentRequestInfo getRequestInfo() const;
 
 private slots:
-   void onURIChanhed();
+   void onURIChanged();
 
    void onBitpayPaymentLoaded(bool result);
 

--- a/BlockSettleUILib/OpenURIDialog.ui
+++ b/BlockSettleUILib/OpenURIDialog.ui
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+***********************************************************************************
+* Copyright (C) 2020, BlockSettle AB
+* Distributed under the GNU Affero General Public License (AGPL v3)
+* See LICENSE or http://www.gnu.org/licenses/agpl.html
+*
+**********************************************************************************
+
+-->
 <ui version="4.0">
  <class>OpenURIDialog</class>
  <widget class="QDialog" name="OpenURIDialog">
@@ -237,84 +247,84 @@
            </item>
           </layout>
          </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBoxBitPayDetails">
+        <property name="title">
+         <string>BitPay Payment Details</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="rightMargin">
+          <number>10</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
          <item>
-          <widget class="QGroupBox" name="groupBoxBitPayDetails">
-           <property name="title">
-            <string>BitPay Payment Details</string>
+          <layout class="QFormLayout" name="formLayout_2">
+           <property name="horizontalSpacing">
+            <number>5</number>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_4">
-            <property name="spacing">
-             <number>5</number>
-            </property>
-            <property name="leftMargin">
-             <number>10</number>
-            </property>
-            <property name="topMargin">
-             <number>5</number>
-            </property>
-            <property name="rightMargin">
-             <number>10</number>
-            </property>
-            <property name="bottomMargin">
-             <number>5</number>
-            </property>
-            <item>
-             <layout class="QFormLayout" name="formLayout_2">
-              <property name="horizontalSpacing">
-               <number>5</number>
-              </property>
-              <property name="verticalSpacing">
-               <number>5</number>
-              </property>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_9">
-                <property name="text">
-                 <string>Expires</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_8">
-                <property name="text">
-                 <string>Fee Rate</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLabel" name="labelDetailsExpires">
-                <property name="text">
-                 <string>...</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLabel" name="labelDetailsFeeRate">
-                <property name="text">
-                 <string>...</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_7">
-                <property name="text">
-                 <string>BitPay Memo</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QLabel" name="labelDetailsMemo">
-                <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="wordWrap">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </widget>
+           <property name="verticalSpacing">
+            <number>5</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_9">
+             <property name="text">
+              <string>Expires</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_8">
+             <property name="text">
+              <string>Fee Rate</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="labelDetailsExpires">
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="labelDetailsFeeRate">
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_7">
+             <property name="text">
+              <string>BitPay Memo</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLabel" name="labelDetailsMemo">
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </widget>

--- a/BlockSettleUILib/OpenURIDialog.ui
+++ b/BlockSettleUILib/OpenURIDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>401</height>
+    <height>422</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -291,6 +291,23 @@
                <widget class="QLabel" name="labelDetailsFeeRate">
                 <property name="text">
                  <string>...</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_7">
+                <property name="text">
+                 <string>BitPay Memo</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QLabel" name="labelDetailsMemo">
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>

--- a/BlockSettleUILib/OpenURIDialog.ui
+++ b/BlockSettleUILib/OpenURIDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>150</height>
+    <width>684</width>
+    <height>404</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,47 +22,285 @@
   <property name="sizeGripEnabled">
    <bool>false</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_7">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QWidget" name="widget_2" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <layout class="QVBoxLayout" name="verticalLayout_6">
       <property name="spacing">
-       <number>10</number>
+       <number>5</number>
       </property>
       <property name="leftMargin">
-       <number>20</number>
+       <number>10</number>
       </property>
       <property name="topMargin">
        <number>5</number>
       </property>
       <property name="rightMargin">
-       <number>20</number>
+       <number>10</number>
       </property>
       <property name="bottomMargin">
        <number>5</number>
       </property>
       <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>URI</string>
+       <widget class="QGroupBox" name="groupBox">
+        <property name="title">
+         <string>Payment URI</string>
         </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="rightMargin">
+          <number>10</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <property name="spacing">
+            <number>10</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>URI</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="lineEditURI">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="placeholderText">
+              <string>bitcoin:</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelErrorMessage">
+           <property name="text">
+            <string>...</string>
+           </property>
+           <property name="errorMessage" stdset="0">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelStatus">
+           <property name="text">
+            <string>...</string>
+           </property>
+           <property name="infoMessage" stdset="0">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="lineEditURI">
-        <property name="text">
-         <string/>
+       <widget class="QGroupBox" name="groupBoxPaymentDetails">
+        <property name="title">
+         <string>Payment Request Details</string>
         </property>
-        <property name="placeholderText">
-         <string>bitcoin:</string>
-        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="rightMargin">
+          <number>10</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
+         <item>
+          <layout class="QFormLayout" name="formLayout">
+           <property name="horizontalSpacing">
+            <number>5</number>
+           </property>
+           <property name="verticalSpacing">
+            <number>5</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>Address</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="labelDetailsAddress">
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_4">
+             <property name="text">
+              <string>Label</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="labelDetailsLabel">
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QLabel" name="labelDetilsAmount">
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>Amount</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_5">
+             <property name="text">
+              <string>Message</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLabel" name="labelDetailsMessage">
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>Request URL</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QLabel" name="labelRequestURL">
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="openExternalLinks">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBoxBitPayDetails">
+           <property name="title">
+            <string>BitPay Payment Details</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_4">
+            <property name="spacing">
+             <number>5</number>
+            </property>
+            <property name="leftMargin">
+             <number>10</number>
+            </property>
+            <property name="topMargin">
+             <number>5</number>
+            </property>
+            <property name="rightMargin">
+             <number>10</number>
+            </property>
+            <property name="bottomMargin">
+             <number>5</number>
+            </property>
+            <item>
+             <layout class="QFormLayout" name="formLayout_2">
+              <property name="horizontalSpacing">
+               <number>5</number>
+              </property>
+              <property name="verticalSpacing">
+               <number>5</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_9">
+                <property name="text">
+                 <string>Expires</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_8">
+                <property name="text">
+                 <string>Fee Rate</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLabel" name="labelDetailsExpires">
+                <property name="text">
+                 <string>...</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLabel" name="labelDetailsFeeRate">
+                <property name="text">
+                 <string>...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
+    <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -86,21 +324,6 @@
       <bool>true</bool>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="spacing">
-       <number>10</number>
-      </property>
-      <property name="leftMargin">
-       <number>20</number>
-      </property>
-      <property name="topMargin">
-       <number>5</number>
-      </property>
-      <property name="rightMargin">
-       <number>20</number>
-      </property>
-      <property name="bottomMargin">
-       <number>5</number>
-      </property>
       <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
@@ -131,16 +354,22 @@
         <property name="text">
          <string>Cancel</string>
         </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
         <property name="default">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="flat">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QPushButton" name="pushButtonOk">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
           <horstretch>0</horstretch>

--- a/BlockSettleUILib/OpenURIDialog.ui
+++ b/BlockSettleUILib/OpenURIDialog.ui
@@ -6,15 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>684</width>
-    <height>404</height>
+    <width>500</width>
+    <height>401</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>500</width>
+    <height>0</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Equity Token Issuance</string>

--- a/BlockSettleUILib/OpenURIDialog.ui
+++ b/BlockSettleUILib/OpenURIDialog.ui
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OpenURIDialog</class>
+ <widget class="QDialog" name="OpenURIDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>150</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Equity Token Issuance</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>false</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QWidget" name="widget_2" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+      <property name="leftMargin">
+       <number>20</number>
+      </property>
+      <property name="topMargin">
+       <number>5</number>
+      </property>
+      <property name="rightMargin">
+       <number>20</number>
+      </property>
+      <property name="bottomMargin">
+       <number>5</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>URI</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="lineEditURI">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="placeholderText">
+         <string>bitcoin:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="buttonBar" stdset="0">
+      <bool>true</bool>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+      <property name="leftMargin">
+       <number>20</number>
+      </property>
+      <property name="topMargin">
+       <number>5</number>
+      </property>
+      <property name="rightMargin">
+       <number>20</number>
+      </property>
+      <property name="bottomMargin">
+       <number>5</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButtonCancel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Cancel</string>
+        </property>
+        <property name="default">
+         <bool>true</bool>
+        </property>
+        <property name="flat">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButtonOk">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Ok</string>
+        </property>
+        <property name="default">
+         <bool>true</bool>
+        </property>
+        <property name="flat">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>pushButtonOk</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/BlockSettleUILib/UiUtils.cpp
+++ b/BlockSettleUILib/UiUtils.cpp
@@ -370,9 +370,9 @@ QPixmap UiUtils::getQRCode(const QString& address, int size)
    }
 }
 
-double UiUtils::parseAmountBtc(const QString& text)
+double UiUtils::parseAmountBtc(const QString& text, bool *converted)
 {
-   return QLocale().toDouble(text);
+   return QLocale().toDouble(text, converted);
 }
 
 QString UiUtils::displayCurrencyAmount(double amount)

--- a/BlockSettleUILib/UiUtils.h
+++ b/BlockSettleUILib/UiUtils.h
@@ -79,7 +79,7 @@ namespace UiUtils
    template <typename T> QString displayAmount(T value);
    QString displayAmount(const bs::XBTAmount &);
 
-   double parseAmountBtc(const QString& text);
+   double parseAmountBtc(const QString& text, bool *converted = nullptr);
 
    QString displayCurrencyAmount(double value);
    QString displayCCAmount(double value);


### PR DESCRIPTION
Support Bip21 and JsonPaymentProtocol v2 from Bitpay

### Bip21 notes

- support encoded and decoded URL. Unicode should be acceptable in Label and Message arguments
- request URL ( Bip70 ) is supported only for BitPay domain ( main and test ). Reason - it is disabled by default in Bitcoin-qt client since v0.19
- simple/advanced dialog displayed based on user settings
- switch between simple/advanced possible
- RBF flag can be set

```
   bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W
   bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?label=Luke-Jr
   bitcoin:tb1q8q5w6cw32ksg2zgrlxaza59ada5ccd2dl4s2c6
   bitcoin:tb1q8q5w6cw32ksg2zgrlxaza59ada5ccd2dl4s2c6?label=Label
   bitcoin:tb1q8q5w6cw32ksg2zgrlxaza59ada5ccd2dl4s2c6?label=Label&message=asd%2Fxxx%20111
   bitcoin:tb1q8q5w6cw32ksg2zgrlxaza59ada5ccd2dl4s2c6?label=Label&message=asd xxx 111
   bitcoin:tb1q8q5w6cw32ksg2zgrlxaza59ada5ccd2dl4s2c6?label=Label&message=asd%2Fxxx%20111&amount=0.11
```

### BitPay

[BitPay protocol reference](https://github.com/bitpay/jsonPaymentProtocol/blob/master/v2/specification.md)

- support encoded and decoded URLs
- RBF disabled ( BitPay requirement )
- only advanced dialog should be used
- request verified before going to TX dialog 
- expire time displayed in user time. verification is not done in terminal. Handled on BitPay side. Any request to expired invoice should fail on bitpay side.
- only TLS is used. Additional checks on response signature from headers.
- unsigned TX is "approved" by BitPay before user sign it.

```
bitcoin:?r=https://test.bitpay.com/i/MhET6oDy2DmN74rqz4RG8d
bitcoin:mqy9sowGyMJXeJcHvVy8MZGBALTCE37FhK?amount=0.002021&r=https%3A%2F%2Ftest.bitpay.com%2Fi%2FTEpvmJZ1gNBg3XF3iKxk8Y
bitcoin:?r=https%3A%2F%2Ftest.bitpay.com%2Fi%2FTEpvmJZ1gNBg3XF3iKxk8Y
bitcoin:?r=https://test.bitpay.com/i/WeYKwcPAezA8SfECtP8PVH
```
