### PR TITLE
Truncate double decimals as needed when pasted

### DIFF
--- a/BlockSettleUILib/UiUtils.cpp
+++ b/BlockSettleUILib/UiUtils.cpp
@@ -620,6 +620,13 @@ QValidator::State UiUtils::ValidateDoubleString(QString &input, int &pos, const 
 
    QString tempCopy = UiUtils::NormalizeString(input);
 
+   QStringList list = tempCopy.split(defaultDecimalsSeparatorChar);
+   if (list.size() == 2 && list[1].length() > decimals && pos == input.length()) {
+      list[1].resize(decimals);
+      input = list[0] + QLatin1Char('.') + list[1];
+      tempCopy = input;
+   }
+
    bool metDecimalSeparator = false;
    int afterDecimal = 0;
 


### PR DESCRIPTION
If user tries to paste `0.2837647058` this will result in pasting `0.28376470` or `0.28` for FX prices (currently pasting such values is not possible and no errors reported).
BST-2801