### PR TITLE
Basic Armory wallets support

### DIFF
--- a/BlockSettleSigner/SignerAdapterListener.cpp
+++ b/BlockSettleSigner/SignerAdapterListener.cpp
@@ -1036,8 +1036,8 @@ bs::error::ErrorCode SignerAdapterListener::verifyOfflineSignRequest(const bs::c
    size_t foundInputCount = 0;
    auto checkAddress = [](const bs::core::WalletsManager::WalletPtr& wallet,
       bs::Address addr) {
-      return wallet->addressType() == addr.getType() ||
-         (addr.getType() == AddressEntryType_P2SH && (wallet->addressType() & addr.getType()));
+      return wallet->defaultAddressType() == addr.getType() ||
+         (addr.getType() == AddressEntryType_P2SH && (wallet->defaultAddressType() & addr.getType()));
    };
 
    for (const auto &walletId : txSignReq.walletIds) { // sync new addresses in all wallets

--- a/BlockSettleSigner/SignerAdapterListener.cpp
+++ b/BlockSettleSigner/SignerAdapterListener.cpp
@@ -399,7 +399,7 @@ bool SignerAdapterListener::onSyncHDWallet(const std::string &data, bs::signer::
          auto groupEntry = response.add_groups();
          groupEntry->set_type(static_cast<bs::hd::CoinType>(group->index()));
 
-         for (const auto &leaf : group->getLeaves()) {
+         for (const auto &leaf : group->getAllLeaves()) {
             auto leafEntry = groupEntry->add_leaves();
             leafEntry->set_id(leaf->walletId());
             leafEntry->set_path(leaf->path().toString());
@@ -472,7 +472,7 @@ bool SignerAdapterListener::sendWoWallet(const std::shared_ptr<bs::core::hd::Wal
    for (const auto &group : wallet->getGroups()) {
       auto groupEntry = response.add_groups();
       groupEntry->set_type(group->index());
-      for (const auto &leaf : group->getLeaves()) {
+      for (const auto &leaf : group->getAllLeaves()) {
          auto leafEntry = groupEntry->add_leaves();
          leafEntry->set_id(leaf->walletId());
          leafEntry->set_path(leaf->path().toString());

--- a/BlockSettleUILib/TransactionDetailDialog.cpp
+++ b/BlockSettleUILib/TransactionDetailDialog.cpp
@@ -135,18 +135,24 @@ TransactionDetailDialog::TransactionDetailDialog(const TransactionPtr &tvi
                   if (addressWallet) {
                      const auto &rootWallet = walletsManager_->getHDRootForLeaf(addressWallet->walletId());
                      if (rootWallet) {
-                        const auto &xbtLeaves = rootWallet->getGroup(rootWallet->getXBTGroupType())->getLeaves();
+                        auto xbtGroup = rootWallet->getGroup(rootWallet->getXBTGroupType());
                         bool isXbtLeaf = false;
-                        for (const auto &leaf : xbtLeaves) {
-                           if (*leaf == *addressWallet) {
-                              isXbtLeaf = true;
-                              break;
+
+                        if (xbtGroup) {
+                           const auto &xbtLeaves = xbtGroup->getLeaves();
+                           for (const auto &leaf : xbtLeaves) {
+                              if (*leaf == *addressWallet) {
+                                 isXbtLeaf = true;
+                                 break;
+                              }
+                           }
+
+                           if (isXbtLeaf) {
+                              inputWallets.insert(xbtLeaves.cbegin(), xbtLeaves.cend());
                            }
                         }
-                        if (isXbtLeaf) {
-                           inputWallets.insert(xbtLeaves.cbegin(), xbtLeaves.cend());
-                        }
-                        else {
+
+                        if (!isXbtLeaf) {
                            inputWallets.insert(addressWallet);
                         }
                      }

--- a/BlockSettleUILib/UtxoReservationManager.cpp
+++ b/BlockSettleUILib/UtxoReservationManager.cpp
@@ -116,7 +116,12 @@ std::vector<UTXO> bs::UTXOReservationManager::getAvailableXbtUTXOs(const HDWalle
    , bs::hd::Purpose purpose) const
 {
    auto hdWallet = walletsManager_->getHDWalletById(walletId);
-   auto leaf = hdWallet->getGroup(hdWallet->getXBTGroupType())->getLeaf(purpose);
+   auto xbtGroup = hdWallet->getGroup(hdWallet->getXBTGroupType());
+   if (xbtGroup == nullptr) {
+      return {};
+   }
+
+   auto leaf = xbtGroup->getLeaf(purpose);
 
    if (!leaf) {
       return {};
@@ -162,7 +167,7 @@ BTCNumericTypes::balance_type bs::UTXOReservationManager::getAvailableCCUtxoSum(
    if (!ccWallet) {
       return {};
    }
-   
+
    BTCNumericTypes::satoshi_type sum = 0;
    auto const availableUtxos = getAvailableCCUTXOs(ccWallet->walletId());
    for (const auto &utxo : availableUtxos) {
@@ -292,7 +297,13 @@ bool bs::UTXOReservationManager::resetHdWallet(const std::string& hdWalledId)
 void bs::UTXOReservationManager::resetSpendableXbt(const std::shared_ptr<bs::sync::hd::Wallet>& hdWallet)
 {
    assert(hdWallet);
-   auto leaves = hdWallet->getGroup(hdWallet->getXBTGroupType())->getLeaves();
+
+   auto xbtGroup = hdWallet->getGroup(hdWallet->getXBTGroupType());
+   if (xbtGroup == nullptr) {
+      return ;
+   }
+
+   auto leaves = xbtGroup->getLeaves();
    std::vector<bs::sync::WalletsManager::WalletPtr> wallets;
    for (const auto &leaf : leaves) {
       auto purpose = leaf->purpose();


### PR DESCRIPTION
- armory wallet could be placed in wallets dir and loaded  to signer and terminal
- wallet will be displayed as Armory group with a single leaf ( which contain all addresses from the account )
- balance and transactions will be properly loaded