### PR TITLE
Fix promote to primary

### DIFF
--- a/BlockSettleUILib/BSTerminalMainWindow.cpp
+++ b/BlockSettleUILib/BSTerminalMainWindow.cpp
@@ -2129,7 +2129,7 @@ void BSTerminalMainWindow::promoteToPrimaryIfNeeded()
    auto primaryWallet = walletsMgr_->getPrimaryWallet();
    if (primaryWallet) {
       for (const auto &leaf : primaryWallet->getLeaves()) {
-         if (leaf->type() == bs::core::wallet::Type::ColorCoin) {
+         if (leaf->type() == bs::core::wallet::Type::Settlement) {
             return;
          }
       }


### PR DESCRIPTION
ColorCoin wallets now always created so old check does not properly work now.
Checking `Settlement` wallet existence seems to fix the problems.